### PR TITLE
Librarification, and using external libraries

### DIFF
--- a/KeyboardioFirmware.ino
+++ b/KeyboardioFirmware.ino
@@ -10,6 +10,11 @@
 uint8_t primary_keymap = 0;
 uint8_t temporary_keymap = 0;
 
+bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState) {
+  //Serial.print ("user_key_event");
+  return false;
+}
+
 void setup() {
     wdt_disable();
     delay(100);

--- a/key_events.cpp
+++ b/key_events.cpp
@@ -46,9 +46,19 @@ void handle_synthetic_key_event(Key mappedKey, uint8_t currentState, uint8_t pre
 
     }
 }
+
+__attribute__((weak))
+bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState) {
+  return false;
+}
+
 void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState) {
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
+
+    if (handle_user_key_event(row, col, currentState, previousState)) {
+        return;
+    }
 
    Key mappedKey;
    mappedKey.raw=  pgm_read_word(&(keymaps[temporary_keymap][row][col]));

--- a/key_events.h
+++ b/key_events.h
@@ -20,3 +20,4 @@ void press_key(Key mappedKey);
 void handle_keymap_key_event(Key keymapEntry, uint8_t currentState, uint8_t previousState);
 void handle_mouse_key_event(Key mappedKey, uint8_t currentState, uint8_t previousState);
 
+bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState);


### PR DESCRIPTION
So the other day I prepared a PoC, see #20, and that got me thinking about how to make it easier to use anything I write for Akela, with KeyboardioFirmware. Then it dawned on me, that this may be actually very simple!

There are two parts to this:

1. Making it possible for Akela libraries to use KeyboardioFirmware as if it was an Akela.
2. Making it possible for KeyboardioFirmware to use Akela libraries.

For the first, if I can use KeyboardioFirmware as a library, then I can write a wrapper that makes it look like Akela, and present the same APIs, and as such, Akela libraries will just work fine.

For the second, a user needs to be able to hook into the main event loop, and into the key event processing flow, and insert their own code, that calls out to Akela libraries. The former is already possbile, with the main `loop` function in the Sketch: we only need to call Akela's keyboard loop function instead of `Keyboard.loop()`. The latter, hooking into key processing is a bit trickier, but not by much: create a `bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState)` function. This would return `true` if the event was processed by this function, and should not be processed further; and false otherwise. In `handle_key_event`, we'd call this function first, and return early if it returns true. This allows the user to override what happens during key handling, and insert new behaviour, such as using the Akela libraries.

By default, this `handle_user_key_event` function would simply return `false`. We'd also tell the linker to mark it `weak`, so any other definition of the same function would override it. This makes it possible to use it from a user Sketch, and hook into the event processing.

All in all, this would be just a few lines of code needed in KeyboardioFirmware, and would add minimal to the code size. Yet, would make it possible to hook into event processing, and make the firmware far more extendable than it currently is, without over-complicating things. May not be the cleanest, nicest way, but it is effective.

What do you think? I can prepare a PoC to show off what I was thinking of. A simple one, that just extends the firmware, without using other libraries, to make it a simple one.