### PR TITLE
Add a lookup_key() method

### DIFF
--- a/key_events.cpp
+++ b/key_events.cpp
@@ -52,6 +52,14 @@ bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t pre
   return false;
 }
 
+Key lookup_key(byte keymap, byte row, byte col) {
+    Key mappedKey;
+
+    mappedKey.raw = pgm_read_word(&(keymaps[keymap][row][col]));
+
+    return mappedKey;
+}
+
 void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState) {
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
@@ -60,10 +68,9 @@ void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previous
         return;
     }
 
-   Key mappedKey;
-   mappedKey.raw=  pgm_read_word(&(keymaps[temporary_keymap][row][col]));
-   Key baseKey;
-   baseKey.raw=    pgm_read_word(&(keymaps[primary_keymap][row][col]));
+    Key mappedKey = lookup_key(temporary_keymap, row, col);
+    Key baseKey   = lookup_key(primary_keymap, row, col);
+
     if (baseKey.flags & SWITCH_TO_KEYMAP) {
         handle_keymap_key_event(baseKey, currentState, previousState);
     } else if (mappedKey.flags & SYNTHETIC_KEY) {

--- a/key_events.h
+++ b/key_events.h
@@ -19,5 +19,6 @@ void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previous
 void press_key(Key mappedKey);
 void handle_keymap_key_event(Key keymapEntry, uint8_t currentState, uint8_t previousState);
 void handle_mouse_key_event(Key mappedKey, uint8_t currentState, uint8_t previousState);
-
 bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState);
+
+Key lookup_key(byte keymap, byte row, byte col);


### PR DESCRIPTION
This allows external libraries to look up the keycode for a given position, without having to reimplement the keymap themselves. This becomes important when you hook into the event processing.