### PR TITLE
Improved custom key event handling

### DIFF
--- a/key_events.cpp
+++ b/key_events.cpp
@@ -52,6 +52,16 @@ bool handle_user_key_event(byte row, byte col, uint8_t currentState, uint8_t pre
   return false;
 }
 
+static custom_handler_t customHandler = handle_user_key_event;
+
+void set_custom_handler(custom_handler_t f) {
+  customHandler = f;
+}
+
+custom_handler_t get_custom_handler() {
+  return customHandler;
+}
+
 Key lookup_key(byte keymap, byte row, byte col) {
     Key mappedKey;
 
@@ -64,7 +74,7 @@ void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previous
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
 
-    if (handle_user_key_event(row, col, currentState, previousState)) {
+    if ((*customHandler)(row, col, currentState, previousState)) {
         return;
     }
 

--- a/key_events.h
+++ b/key_events.h
@@ -13,6 +13,11 @@
 extern uint8_t primary_keymap;
 extern uint8_t temporary_keymap;
 
+typedef bool (*custom_handler_t)(byte row, byte col, uint8_t currentState, uint8_t previousState);
+
+void set_custom_handler(custom_handler_t f);
+custom_handler_t get_custom_handler();
+
 // sending events to the computer
 void handle_synthetic_key_event( Key mappedKey, uint8_t currentState, uint8_t previousState);
 void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState);


### PR DESCRIPTION
Instead of always calling handle_user_key_event(), call a function
pointed to by the customHandler variable. This makes it possible to
override what function gets called, at run time, at very little cost.

The reason for this change is to be able to change the user function
into a testing one, if a magic combo is pressed, while still allowing
the end-user to fully customize handle_user_key_event, and allow them to
have access to the testing one too, without them doing anything special.