### PR TITLE
Some more hook work

### DIFF
--- a/KeyboardioFirmware.cpp
+++ b/KeyboardioFirmware.cpp
@@ -16,8 +16,15 @@ Keyboardio_::setup(void) {
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(KEYMAPS);
 }
 
+custom_loop_t loopHooks[HOOK_MAX] = {NULL};
+
 void
 Keyboardio_::loop(void) {
+    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
+        custom_loop_t hook = loopHooks[i];
+        (*hook)();
+    }
+
     KeyboardHardware.scan_matrix();
     LEDControl.update(temporary_keymap);
     Keyboard.sendReport();

--- a/KeyboardioFirmware.cpp
+++ b/KeyboardioFirmware.cpp
@@ -1,0 +1,26 @@
+#include "KeyboardioFirmware.h"
+
+Keyboardio_::Keyboardio_(void) {
+}
+
+void
+Keyboardio_::setup(void) {
+    wdt_disable();
+    delay(100);
+    Keyboard.begin();
+    Mouse.begin();
+    AbsoluteMouse.begin();
+    KeyboardHardware.setup();
+    LEDControl.boot_animation();
+
+    temporary_keymap = primary_keymap = Storage.load_primary_keymap(KEYMAPS);
+}
+
+void
+Keyboardio_::loop(void) {
+    KeyboardHardware.scan_matrix();
+    LEDControl.update(temporary_keymap);
+    Keyboard.sendReport();
+    Keyboard.releaseAll();
+}
+

--- a/KeyboardioFirmware.h
+++ b/KeyboardioFirmware.h
@@ -34,3 +34,12 @@ extern uint8_t temporary_keymap;
 #define VERSION "locally-built"
 #endif
 
+class Keyboardio_ {
+  public:
+    Keyboardio_(void);
+
+    void setup(void);
+    void loop(void);
+};
+
+static Keyboardio_ Keyboardio;

--- a/KeyboardioFirmware.ino
+++ b/KeyboardioFirmware.ino
@@ -4,30 +4,17 @@
 #define DEBUG_SERIAL false
 
 #include "KeyboardioFirmware.h"
-#include "KeyboardioHID.h"
-
 
 uint8_t primary_keymap = 0;
 uint8_t temporary_keymap = 0;
 
 void setup() {
-    wdt_disable();
-    delay(100);
-    Keyboard.begin();
-    Mouse.begin();
-    AbsoluteMouse.begin();
-    KeyboardHardware.setup();
-    LEDControl.boot_animation();
-
-    temporary_keymap = primary_keymap = Storage.load_primary_keymap(KEYMAPS);
+    Keyboardio.setup();
 }
 
 
 void loop() {
-    KeyboardHardware.scan_matrix();
-    LEDControl.update(temporary_keymap);
-    Keyboard.sendReport();
-    Keyboard.releaseAll();
+    Keyboardio.loop();
 }
 
 

--- a/hooks.cpp
+++ b/hooks.cpp
@@ -1,0 +1,27 @@
+#include "hooks.h"
+
+void
+event_handler_hook_add (custom_handler_t hook) {
+    byte i;
+
+    for (i = 0; i < HOOK_MAX && eventHandlers[i] != NULL; i++) {
+    }
+
+    if (i == HOOK_MAX)
+        return;
+
+    eventHandlers[i] = hook;
+}
+
+void
+loop_hook_add (custom_loop_t hook) {
+    byte i;
+
+    for (i = 0; i < HOOK_MAX && loopHooks[i] != NULL; i++) {
+    }
+
+    if (i == HOOK_MAX)
+        return;
+
+    loopHooks[i] = hook;
+}

--- a/hooks.h
+++ b/hooks.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Arduino.h>
+
+#define HOOK_MAX 64
+
+typedef bool (*custom_handler_t)(byte row, byte col, uint8_t currentState, uint8_t previousState);
+extern custom_handler_t eventHandlers[HOOK_MAX];
+
+void event_handler_hook_add (custom_handler_t hook);
+
+typedef void (*custom_loop_t)(void);
+extern custom_loop_t loopHooks[HOOK_MAX];
+
+void loop_hook_add (custom_loop_t hook);

--- a/key_events.cpp
+++ b/key_events.cpp
@@ -41,8 +41,7 @@ void handle_synthetic_key_event(Key mappedKey, uint8_t currentState, uint8_t pre
     }
 }
 
-__attribute__((weak))
-custom_handler_t eventHandlers[] = {
+custom_handler_t eventHandlers[HOOK_MAX] = {
     handle_key_event_default,
     (custom_handler_t) NULL
 };
@@ -56,7 +55,7 @@ Key lookup_key(byte keymap, byte row, byte col) {
 }
 
 void handle_key_event(byte row, byte col, uint8_t currentState, uint8_t previousState) {
-    for (byte i = 0; eventHandlers[i] != NULL; i++) {
+    for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
         custom_handler_t handler = eventHandlers[i];
         if ((*handler)(row, col, currentState, previousState))
             return;

--- a/key_events.h
+++ b/key_events.h
@@ -8,13 +8,11 @@
 #include "Storage.h"
 #include "keymap_metadata.h"
 #include "generated/keymaps.h"
+#include "hooks.h"
 
 //static const Key keymaps[KEYMAPS][ROWS][COLS];
 extern uint8_t primary_keymap;
 extern uint8_t temporary_keymap;
-
-typedef bool (*custom_handler_t)(byte row, byte col, uint8_t currentState, uint8_t previousState);
-extern custom_handler_t eventHandlers[];
 
 // sending events to the computer
 void handle_synthetic_key_event( Key mappedKey, uint8_t currentState, uint8_t previousState);


### PR DESCRIPTION
These two commits hide most of `KeyboardioFirmware.ino`, so that we can later use an object constructor to do a few things, and introduce hooks for the `loop()` function too.

Hook arrays are pre-allocated, for 64 elements, and helpers are provided to append a new hook to them.