### PR TITLE
library.properties: Drop the dot_a_linkage setting

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,3 @@ paragraph=...
 category=Communication
 url=https://github.com/keyboardio/KeyboardioFirmware
 architectures=avr
-dot_a_linkage=true


### PR DESCRIPTION
It only causes trouble when trying to use the library from another one, and for the KeyboardioFirmware, serves no useful purpose.
