### PR TITLE
Add the default key event handler in Keyboardio_::setup

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -5,6 +5,7 @@ Keyboardio_::Keyboardio_(void) {
 
 void
 Keyboardio_::setup(void) {
+    event_handler_hook_add (handle_key_event_default);
     wdt_disable();
     delay(100);
     Keyboard.begin();

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -41,10 +41,7 @@ void handle_synthetic_key_event(Key mappedKey, uint8_t currentState, uint8_t pre
     }
 }
 
-custom_handler_t eventHandlers[HOOK_MAX] = {
-    handle_key_event_default,
-    (custom_handler_t) NULL
-};
+custom_handler_t eventHandlers[HOOK_MAX] = {NULL};
 
 Key lookup_key(byte keymap, byte row, byte col) {
     Key mappedKey;


### PR DESCRIPTION
Having the default handler in the list by default prevents other things to hook up before it. Add it in `Keyboardio_::setup` instead, so that others have a chance to add themselves first.