### PR TITLE
Fix the SCANBIT macro by forcing it to use 32 bits

### DIFF
--- a/src/Model01.h
+++ b/src/Model01.h
@@ -48,7 +48,7 @@ class Model01 {
 
 };
 
-#define SCANBIT(row,col) (1 << (row * 8 + (7 - col)))
+#define SCANBIT(row,col) ((uint32_t)1 << (row * 8 + (7 - col)))
 
 #define R0C0  SCANBIT(0, 0)
 #define R0C1  SCANBIT(0, 1)


### PR DESCRIPTION
Naively using the "1 << n" shifting will default to 8 bits, because 1 fits in there. To make it 32-bit aware, not just by context (at which point the damage may have already be done), force the "1" into a uint32_t.

This silences the warnings, and also corrects the defines.

Sorry for not thinking of, and catching this earlier. Only got around to test the macros now.