### PR TITLE
hooks: Add a way to replace hooks

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -3,11 +3,13 @@
 byte NUMPAD_KEYMAP = 0;
 
 Keyboardio_::Keyboardio_(void) {
+    memset(eventHandlers, 0, HOOK_MAX * sizeof(custom_handler_t));
+    memset(loopHooks, 0, HOOK_MAX * sizeof(custom_handler_t));
 }
 
 void
 Keyboardio_::setup(const byte keymap_count, const byte numpad_layer) {
-    event_handler_hook_add (handle_key_event_default);
+    event_handler_hook_add(handle_key_event_default);
     wdt_disable();
     delay(100);
     Keyboard.begin();
@@ -20,7 +22,7 @@ Keyboardio_::setup(const byte keymap_count, const byte numpad_layer) {
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
 }
 
-custom_loop_t loopHooks[HOOK_MAX] = {NULL};
+custom_loop_t loopHooks[HOOK_MAX];
 
 void
 Keyboardio_::loop(void) {

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -1,27 +1,31 @@
 #include "hooks.h"
 
 void
-event_handler_hook_add (custom_handler_t hook) {
-    byte i;
-
-    for (i = 0; i < HOOK_MAX && eventHandlers[i] != NULL; i++) {
+event_handler_hook_replace (custom_handler_t oldHook, custom_handler_t newHook) {
+    for (byte i = 0; i < HOOK_MAX; i++) {
+        if (eventHandlers[i] == oldHook) {
+            eventHandlers[i] = newHook;
+            return;
+        }
     }
+}
 
-    if (i == HOOK_MAX)
-        return;
+void
+event_handler_hook_add (custom_handler_t hook) {
+    event_handler_hook_replace ((custom_handler_t)NULL, hook);
+}
 
-    eventHandlers[i] = hook;
+void
+loop_hook_replace (custom_loop_t oldHook, custom_loop_t newHook) {
+    for (byte i = 0; i < HOOK_MAX; i++) {
+        if (loopHooks[i] == oldHook) {
+            loopHooks[i] = newHook;
+            return;
+        }
+    }
 }
 
 void
 loop_hook_add (custom_loop_t hook) {
-    byte i;
-
-    for (i = 0; i < HOOK_MAX && loopHooks[i] != NULL; i++) {
-    }
-
-    if (i == HOOK_MAX)
-        return;
-
-    loopHooks[i] = hook;
+    loop_hook_replace ((custom_loop_t)NULL, hook);
 }

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -9,8 +9,10 @@ typedef bool (*custom_handler_t)(Key mappedKey, byte row, byte col, uint8_t curr
 extern custom_handler_t eventHandlers[HOOK_MAX];
 
 void event_handler_hook_add (custom_handler_t hook);
+void event_handler_hook_replace (custom_handler_t oldHook, custom_handler_t newHook);
 
 typedef void (*custom_loop_t)(void);
 extern custom_loop_t loopHooks[HOOK_MAX];
 
 void loop_hook_add (custom_loop_t hook);
+void loop_hook_replace (custom_loop_t oldHook, custom_loop_t newHook);

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -39,7 +39,7 @@ void handle_synthetic_key_event(Key mappedKey, uint8_t currentState, uint8_t pre
     }
 }
 
-custom_handler_t eventHandlers[HOOK_MAX] = {NULL};
+custom_handler_t eventHandlers[HOOK_MAX];
 
 Key lookup_key(byte keymap, byte row, byte col) {
     Key mappedKey;


### PR DESCRIPTION
To make replacing work sanely, we first NULL out both the eventHandlers
and loopHooks arrays in the Keyboardio_ constructor. This allows the
replace functions to just run through the whole array, and either see
hook pointers there, or NULL. So they don't need to be afraid of garbage
being there.

This makes the replacing very easy: run through the array, and replace
the first occurrence of the old hook with the new. This further
simplifies addition: the old hook we pass in, will be NULL. If we run
out of space, it silently fails, like before.

Replacing hooks is important for cases where one wants to build features
that can be toggled off, or their behaviour otherwise changed at
run-time. In this case, the most efficent way is to replace the hook,
which is what these new helpers allow us to do.

This closes #36.

No docs for now, will work on those when things are a tiny bit closer to a state where I feel more confident that they won't need to change again.