### PR TITLE
key_events: look up mappedKey earlier

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -50,6 +50,9 @@ Key lookup_key(byte keymap, byte row, byte col) {
 }
 
 void handle_key_event(Key mappedKey, byte row, byte col, uint8_t currentState, uint8_t previousState) {
+    if (mappedKey.raw == Key_NoKey.raw) {
+        mappedKey = lookup_key(temporary_keymap, row, col);
+    }
     for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
         custom_handler_t handler = eventHandlers[i];
         if ((*handler)(mappedKey, row, col, currentState, previousState))
@@ -61,10 +64,10 @@ bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t current
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
 
+    Key baseKey = Key_NoKey;
     if (mappedKey.raw == Key_NoKey.raw) {
-      mappedKey = lookup_key(temporary_keymap, row, col);
+      baseKey = lookup_key(primary_keymap, row, col);
     }
-    Key baseKey   = lookup_key(primary_keymap, row, col);
 
     if ((baseKey.flags & SWITCH_TO_KEYMAP
       || baseKey.flags & SWITCH_TO_KEYMAP_MOMENTARY)) {


### PR DESCRIPTION
Do the mappedKey lookup earlier, in handle_key_event, so that if any of
our handlers need to look at the mapped key, they do not have to look it
up themselves. This simplifies plugged hooks considerably, as they can
always assume that the mapped key they receive is correct. They still
receive enough information to do the lookup themselves, though, if they
ever need that.

Additionally, in handle_key_event_default, baseKey is only looked up if
mappedKey was NoKey. This is so that hooks can defer to this function,
via handle_key_event, setting their own mappedKey, without having to
worry about setting a row/col that would map to a special key on the
base layer.

Fixes #39.