### PR TITLE
TestMode: return false in the event handler hook

### DIFF
--- a/src/TestMode.cpp
+++ b/src/TestMode.cpp
@@ -63,6 +63,7 @@ void TestMode_::setup() {
 }
 bool handle_key_event_test(Key mappedKey, byte row, byte col, uint8_t currentState, uint8_t previousState) {
     Serial.write(row);
+    return false;
 }
 
 TestMode_ TestMode;


### PR DESCRIPTION
After writing the row to Serial, return false, so that the key will be further processed by the next handler. Also fixes a compile-time warning with `-Wall`.
