### PR TITLE
Fix a warning in led_get_crgb_at

### DIFF
--- a/src/Model01.cpp
+++ b/src/Model01.cpp
@@ -50,6 +50,8 @@ cRGB Model01::led_get_crgb_at(uint8_t i) {
         return leftHand.ledData.leds[i];
     } else if (i<64) {
         return rightHand.ledData.leds[i-32] ;
+    } else {
+        return {0, 0, 0};
     }
 }
 


### PR DESCRIPTION
Instead of not handling the case where the LED index is out of range, and thus producing a warning, return a black color instead. It's as good as anything else, but at least gets rid of the warning.

And, it goes hand-in-hand with the set counterpart, which, in a similar case, does nothing: thus the out-of-range LED remains black forever.