### PR TITLE
LEDUtils: Fix the BreathState typedef

### DIFF
--- a/src/LEDUtils.h
+++ b/src/LEDUtils.h
@@ -2,10 +2,10 @@
 
 #include "KeyboardConfig.h"
 
-typedef struct BreathState {
+typedef struct {
   uint8_t brightness = 0;    // how bright the LED is
   int8_t fadeAmount  = 1;    // how many points to fade the LED by (can be negative)
-};
+} BreathState;
 
 cRGB breath_compute (BreathState *state);
 cRGB hsv_to_rgb(uint16_t h, uint16_t s, uint16_t v);


### PR DESCRIPTION
Move the name after the struct, to silence a compiler warning with -Wall.