### PR TITLE
Implement Model01::led_set_crgb_at(row, col, color)

### DIFF
--- a/src/KeyboardConfig.cpp
+++ b/src/KeyboardConfig.cpp
@@ -6,6 +6,9 @@ HARDWARE_IMPLEMENTATION KeyboardHardware;
 void led_set_crgb_at(uint8_t i, cRGB crgb) {
     KeyboardHardware.led_set_crgb_at(i,crgb);
 }
+void led_set_crgb_at(byte row, byte col, cRGB color) {
+    KeyboardHardware.led_set_crgb_at(row,col,color);
+}
 cRGB led_get_crgb_at(uint8_t i) {
     return KeyboardHardware.led_get_crgb_at(i);
 }

--- a/src/KeyboardConfig.h
+++ b/src/KeyboardConfig.h
@@ -10,6 +10,7 @@
 // and the 'userspace' LED implementation. If my C++ were stronger, there woudl
 // certainly be a better way -JV 2016-02-01
 void led_set_crgb_at(uint8_t i, cRGB crgb);
+void led_set_crgb_at(byte row, byte col, cRGB color);
 cRGB led_get_crgb_at(uint8_t i);
 void led_sync(void);
 

--- a/src/Model01.cpp
+++ b/src/Model01.cpp
@@ -2,6 +2,13 @@
 KeyboardioScanner Model01::leftHand(0);
 KeyboardioScanner Model01::rightHand(3);
 
+static constexpr uint8_t key_led_map[4][16] = {
+  {3,4,11,12,19,20,26,27,     36,37,43,44,51,52,59,60},
+  {2,5,10,13,18,21,31,28,     35,32,42,45,50,53,58,61},
+  {1,6,9,14, 17,22,25,29,     34,38,41,46,49,54,57,62},
+  {0,7,8,15,16,23,24,30,      33,39,40,47,48,55,56,63},
+};
+
 Model01::Model01(void) {
 
 }
@@ -53,6 +60,10 @@ void Model01::led_set_crgb_at(uint8_t i, cRGB crgb) {
         // TODO how do we want to handle debugging assertions about crazy user
         // code that would overwrite other memory?
     }
+}
+
+void Model01::led_set_crgb_at(byte row, byte col, cRGB color) {
+    led_set_crgb_at(key_led_map[row][col], color);
 }
 
 cRGB Model01::led_get_crgb_at(uint8_t i) {

--- a/src/Model01.h
+++ b/src/Model01.h
@@ -37,15 +37,6 @@ class Model01 {
   private:
     static KeyboardioScanner leftHand;
     static KeyboardioScanner rightHand;
-
-    static constexpr uint8_t key_led_map[4][16] = {
-        {3,4,11,12,19,20,26,27,     36,37,43,44,51,52,59,60},
-        {2,5,10,13,18,21,31,28,     35,32,42,45,50,53,58,61},
-        {1,6,9,14, 17,22,25,29,     34,38,41,46,49,54,57,62},
-        {0,7,8,15,16,23,24,30,      33,39,40,47,48,55,56,63},
-    };
-
-
 };
 
 #define SCANBIT(row,col) ((uint32_t)1 << (row * 8 + (7 - col)))


### PR DESCRIPTION
While this function had a declaration in the header, it lacked an implementation. With this patch, `key_led_map` moves to the cpp from the header, and the function gains an implementation.

An additional helper, `led_set_crgb_at(row, col, color)` is added too, similarly to the other arities.

This makes it a lot easier to address LEDs when knowing the key position.