### PR TITLE
LEDControl: Add a way to activate a mode by pointer

### DIFF
--- a/src/LEDControl.cpp
+++ b/src/LEDControl.cpp
@@ -1,5 +1,10 @@
 #include "LEDControl.h"
 
+void
+LEDMode::activate (void) {
+  LEDControl.activate (this);
+}
+
 LEDControl_::LEDControl_(void) {
   memset (modes, 0, LED_MAX_MODES * sizeof (modes[0]));
 }
@@ -52,6 +57,14 @@ LEDControl_::set_mode (uint8_t mode) {
 uint8_t
 LEDControl_::get_mode (void) {
   return mode;
+}
+
+void
+LEDControl_::activate (LEDMode *mode) {
+  for (uint8_t i = 0; i < LED_MAX_MODES; i++) {
+    if (modes[i] == mode)
+      return set_mode(i);
+  }
 }
 
 int8_t

--- a/src/LEDControl.h
+++ b/src/LEDControl.h
@@ -10,6 +10,7 @@ class LEDMode {
   virtual void setup (void) {};
   virtual void init (void) {};
   virtual void update (void) {};
+  virtual void activate (void);
 };
 
 class LEDControl_ {
@@ -25,6 +26,8 @@ class LEDControl_ {
 
     void set_all_leds_to(uint8_t r, uint8_t g, uint8_t b);
     void set_all_leds_to(cRGB color);
+
+    void activate (LEDMode *mode);
 
  private:
     LEDMode *modes[LED_MAX_MODES];


### PR DESCRIPTION
It would be nice if LED effects could be activated via their object, not just their number, so that one could write - say, in a macro - `myEffect.activate()`, and have it become the active mode.

To implement this, `LEDControl_` gains an `activate` method, that takes a pointer, finds it in the mode array, and switches to its index (if found). `LEDMode` gains an `activate` method too, which uses `LEDControl`s new method of the same name to activate itself.
