### PR TITLE
Introduce a helper macro to compute the keymap size

### DIFF
--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -19,7 +19,6 @@
 uint8_t primary_keymap = 0;
 uint8_t temporary_keymap = 0;
 
-#define KEYMAPS 3
 #define NUMPAD_KEYMAP 2
 #define KEYMAP_LIST KEYMAP_QWERTY KEYMAP_GENERIC_FN2 KEYMAP_NUMPAD
 
@@ -42,7 +41,7 @@ static LEDChaseEffect chaseEffect;
 static LEDNumlock numLockEffect (NUMPAD_KEYMAP);
 
 void setup() {
-    Keyboardio.setup(KEYMAPS);
+    Keyboardio.setup(KEYMAP_SIZE);
     bootAnimation();
 }
 

--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -33,6 +33,8 @@ extern uint8_t temporary_keymap;
 #define VERSION "locally-built"
 #endif
 
+#define KEYMAP_SIZE (sizeof(keymaps) / ROWS / COLS / sizeof(Key))
+
 class Keyboardio_ {
   public:
     Keyboardio_(void);


### PR DESCRIPTION
When one adds or removes a layer from a keymap, the keymap size has to be adjusted in the call to `Keyboardio.setup()`. This is easy to forget, so as a helper, introduce `KEYMAP_SIZE`, a macro that automatically computes the size at compile time.

This way, one does not need to remember to update the size anywhere.