### PR TITLE
Don't do the bootAnimation in the default example

### DIFF
--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -8,7 +8,6 @@
 #include "KeyboardioFirmware.h"
 #include "generated/keymaps.h"
 
-#include "BootAnimation.h"
 #include "LED-Off.h"
 #include "LED-SolidColor.h"
 #include "LED-Numlock.h"
@@ -42,7 +41,6 @@ static LEDNumlock numLockEffect (NUMPAD_KEYMAP);
 
 void setup() {
     Keyboardio.setup(KEYMAP_SIZE);
-    bootAnimation();
 }
 
 


### PR DESCRIPTION
Because the animation saves if it has been run, it may do so during factory testing. But running it every time is annoying, too. So as per @obra's request, the code for the animation is kept, but removed from the default sketch.
