### PR TITLE
Reintroduce dot_a_linkage

### DIFF
--- a/libraries/Keyboardio-MouseKeys/library.properties
+++ b/libraries/Keyboardio-MouseKeys/library.properties
@@ -7,3 +7,4 @@ paragraph=...
 category=Communication
 url=https://github.com/keyboardio/KeyboardioFirmware
 architectures=avr
+dot_a_linkage=true

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=...
 category=Communication
 url=https://github.com/keyboardio/KeyboardioFirmware
 architectures=avr
+dot_a_linkage=true


### PR DESCRIPTION
The reason it was removed before no longer applies, and enabling it saves noticeable amounts of size when using KeyboardioFirmware as a library.