### PR TITLE
MouseKeys: Make MouseKeys static

### DIFF
--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -56,5 +56,3 @@ static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState)
 MouseKeys_::MouseKeys_(void) {
     event_handler_hook_add (handleMouseKeys);
 }
-
-MouseKeys_ MouseKeys;

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
@@ -7,4 +7,4 @@ class MouseKeys_ {
     MouseKeys_ (void);
 };
 
-extern MouseKeys_ MouseKeys;
+static MouseKeys_ MouseKeys;


### PR DESCRIPTION
When we mark a symbol extern, but do not reference it anywhere else directly, it will not be compiled in when using dot_a_linkage. For this reason, make MouseKeys a static variable instead of extern.