### PR TITLE
MouseKeys: include KeyboardioFirmware.h

### DIFF
--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "KeyboardioFirmware.h"
 #include "MouseKeyDefs.h"
 
 class MouseKeys_ {

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "key_defs.h"
-
 #define IS_MOUSE_KEY     		   B00010000
 
 // Synthetic, not internal


### PR DESCRIPTION
Instead of including `key_defs.h`, include `KeyboardioFirmware.h` in `Keyboardio-MouseKeys.h`, so that the dependency is clear. This is needed for the arduino-builder to arrange the linking order properly when using KeyboardioFirmware, KeyboardioFirmware-MouseKeys and other libraries combined. It does not affect the combination of just the two, but if there's a third, that happens to include `KeyboardioFirmware.h` too, this dependency is required for correct linking.
