### PR TITLE
Call the loop hooks after doing the other loop actions

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -21,14 +21,14 @@ custom_loop_t loopHooks[HOOK_MAX];
 
 void
 Keyboardio_::loop(void) {
-    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
-        custom_loop_t hook = loopHooks[i];
-        (*hook)();
-    }
-
     KeyboardHardware.scan_matrix();
     LEDControl.update();
     Keyboard.sendReport();
     Keyboard.releaseAll();
+
+    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
+      custom_loop_t hook = loopHooks[i];
+      (*hook)();
+    }
 }
 


### PR DESCRIPTION
Instead of calling loop hooks before anything else, including scanning the matrix, call it after all that, at the end of `Keyboardio_::loop()`. This is less surprising, and should not have any ill side-effects, either.

(Based on a discussion with @obra on IRC.)
