### PR TITLE
A few convenience macros

### DIFF
--- a/libraries/Keyboardio-Macros/src/MacroSteps.h
+++ b/libraries/Keyboardio-Macros/src/MacroSteps.h
@@ -13,6 +13,7 @@ typedef uint8_t macro_t;
 
 #define MACRO_NONE 0
 #define MACRO(...) ({static const macro_t __m[] PROGMEM = { __VA_ARGS__ }; &__m[0]; })
+#define MACRODOWN(...) (key_toggled_on(keyState) ? MACRO(__VA_ARGS__) : MACRO_NONE)
 
 #define I(n)  MACRO_ACTION_STEP_INTERVAL, n
 #define W(n)  MACRO_ACTION_STEP_WAIT, n

--- a/libraries/Keyboardio-Macros/src/MacroSteps.h
+++ b/libraries/Keyboardio-Macros/src/MacroSteps.h
@@ -14,9 +14,12 @@ typedef uint8_t macro_t;
 #define MACRO_NONE 0
 #define MACRO(...) ({static const macro_t __m[] PROGMEM = { __VA_ARGS__ }; &__m[0]; })
 
-#define I(n) MACRO_ACTION_STEP_INTERVAL, n
-#define W(n) MACRO_ACTION_STEP_WAIT, n
-#define D(k) MACRO_ACTION_STEP_KEYDOWN, (Key_ ## k).flags, (Key_ ## k).rawKey
-#define U(k) MACRO_ACTION_STEP_KEYUP, (Key_ ## k).flags, (Key_ ## k).rawKey
-#define T(k) D(k), U(k)
-#define END  MACRO_ACTION_END
+#define I(n)  MACRO_ACTION_STEP_INTERVAL, n
+#define W(n)  MACRO_ACTION_STEP_WAIT, n
+#define Dr(k) MACRO_ACTION_STEP_KEYDOWN, (k).flags, (k).rawKey
+#define D(k)  Dr(Key_ ## k)
+#define Ur(k) MACRO_ACTION_STEP_KEYUP, (k).flags, (k).rawKey
+#define U(k)  Ur(Key_ ## k)
+#define Tr(k) Dr(k), Ur(k)
+#define T(k)  D(k), U(k)
+#define END   MACRO_ACTION_END


### PR DESCRIPTION
This introduces a few convenience macros:

- `Dr`, `Ur`, and `Tr`: versions of `D`, `U` and `T`, that work with raw `Key`s, and don't prepend `Key_` to their argument. These are useful when one wants to use custom keys, or on-the-fly constructed codes.
- `MACRODOWN`, to be called from the `macroAction` function, that only plays the macro when `keyState` indicates that the key has just been toggled on. This makes it a little bit nicer to create simple macros, such as this:

```c++
const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
  switch (macroIndex) {
  case M_EXAMPLE:
    return MACRODOWN(T(F), T(O), T(O), END):
  }
}
```