### PR TITLE
key_defs: Helpers for holding mods with keys

### DIFF
--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -249,4 +249,8 @@ typedef union {
 
 #define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL, LED_TOGGLE }
 
-
+#define LCTRL(k)  (Key) { k.flags | CTRL_HELD, k.rawKey }
+#define LALT(k)   (Key) { k.flags | LALT_HELD, k.rawKey }
+#define RALT(k)   (Key) { k.flags | RALT_HELD, k.rawKey }
+#define LSHIFT(k) (Key) { k.flags | SHIFT_HELD, k.rawKey }
+#define LGUI(k)   (Key) { k.flags | GUI_HELD, k.rawKey }


### PR DESCRIPTION
Add a number of helper macros that aid in constructing the Key code for keys with modifiers held. These can, of course, be embedded in each other, so to have a key on the keymap that has all currently supported modifiers pressed, along with `X`, one would write:

 `LCTRL(LALT(RALT(LSHIFT(LGUI(X)))))`

This is most useful for macros, together with the `Tr` helper introduced by #63.