### PR TITLE
generate_keymaps: Don't prepend Key_ to everything

### DIFF
--- a/tools/generate_keymaps.pl
+++ b/tools/generate_keymaps.pl
@@ -15,7 +15,7 @@ for my $line (@data) {
 	}
 
 	my @keys = split(/\s+/, $line);
-	push @map, join(', ', map{ 'Key_'.lookup($_).'' } @keys);
+	push @map, join(', ', map{ ''.lookup($_).'' } @keys);
 }
 
 print "#define KEYMAP_$name { /* Generated keymap for $name */ ";
@@ -27,23 +27,24 @@ print "},\n";
 sub lookup {
 
 my %table = (
-'{' => 'LCurlyBracket',
-'}' => 'RCurlyBracket',
-'['=> 'LSquareBracket',
-']'=> 'RSquareBracket',
-'|'=> 'Pipe',
-'\\' => 'Backslash',
+'{' => 'Key_LCurlyBracket',
+'}' => 'Key_RCurlyBracket',
+'['=> 'Key_LSquareBracket',
+']'=> 'Key_RSquareBracket',
+'|'=> 'Key_Pipe',
+'\\' => 'Key_Backslash',
 
-	';' => 'Semicolon',
-	',' => 'Comma',
-	'.' => 'Period',
-	'/' => 'Slash',
-	"'" => 'Quote',
-	'`' => 'Backtick',
-	'-' => 'Minus',
-	'=' => 'Equals');
+	';' => 'Key_Semicolon',
+	',' => 'Key_Comma',
+	'.' => 'Key_Period',
+	'/' => 'Key_Slash',
+	"'" => 'Key_Quote',
+	'`' => 'Key_Backtick',
+	'-' => 'Key_Minus',
+	'=' => 'Key_Equals');
 
-	my $x = shift;
-	return $x unless defined $table{$x};
+  my $x = shift;
+  return $x if $x =~ /\(.*\)/;
+	return 'Key_'.$x unless defined $table{$x};
 	return $table{$x};
 }


### PR DESCRIPTION
If a key in the layout has parens, leave it there as-is. This makes it a lot easier to have macros and whatnot in the layout: one can just use `M(0)` and the like.
