### PR TITLE
Major hook system rework

### DIFF
--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -24,7 +24,6 @@ uint8_t temporary_keymap = 0;
 
 const Key keymaps[][ROWS][COLS] PROGMEM = { KEYMAP_LIST };
 
-static LEDOff LEDSOff;
 static LEDSolidColor solidRed (100, 0, 0);
 static LEDSolidColor solidOrange (100, 30, 0);
 static LEDSolidColor solidYellow (90, 70, 0);
@@ -32,11 +31,6 @@ static LEDSolidColor solidGreen (0, 200, 0);
 static LEDSolidColor solidBlue (0, 30, 200);
 static LEDSolidColor solidIndigo (0, 0, 200);
 static LEDSolidColor solidViolet (100, 0, 120);
-
-static LEDBreatheEffect breatheEffect;
-static LEDRainbowEffect rainbowEffect;
-static LEDRainbowWaveEffect rainbowWaveEffect;
-static LEDChaseEffect chaseEffect;
 
 static LEDNumlock numLockEffect (NUMPAD_KEYMAP);
 
@@ -54,7 +48,16 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 }
 
 void setup() {
+    Keyboardio.use(&LEDOff,
+                   &solidRed, &solidOrange, &solidYellow, &solidGreen, &solidBlue, &solidIndigo, &solidViolet,
+                   &LEDBreatheEffect, &LEDRainbowEffect, &LEDChaseEffect, &numLockEffect,
+
+                   &Macros,
+                   &MouseKeys,
+                   NULL);
+
     Keyboardio.setup(KEYMAP_SIZE);
+    LEDOff.activate();
 }
 
 

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -45,8 +45,11 @@ void Macros_::play(const macro_t *macro_p) {
 }
 
 static bool handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (!(mappedKey.flags & (SYNTHETIC|IS_MACRO)) || (mappedKey.flags & IS_INTERNAL))
+    if (mappedKey.flags != (SYNTHETIC | IS_MACRO))
         return false;
+
+    if (!key_toggled_on(keyState))
+      return true;
 
     const macro_t *m = macroAction(mappedKey.rawKey, keyState);
 

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -55,5 +55,11 @@ static bool handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState
 }
 
 Macros_::Macros_ (void) {
+}
+
+void
+Macros_::begin (void) {
     event_handler_hook_add (handleMacroEvent);
 }
+
+Macros_ Macros;

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.h
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.h
@@ -7,11 +7,13 @@
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
 
-class Macros_ {
+class Macros_ : public KeyboardioPlugin {
   public:
     Macros_(void);
+
+    virtual void begin(void) final;
 
     void play(const macro_t *macro_p);
 };
 
-static Macros_ Macros;
+extern Macros_ Macros;

--- a/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
+++ b/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MACRO       B00000001
+#define IS_MACRO       B00000100
 
 #define M(n)           (Key){ KEY_FLAGS|SYNTHETIC|IS_MACRO, n}
 #define Key_macroKey1  M(1)

--- a/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
+++ b/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MACRO       B00000100
+#define IS_MACRO       B00100000
 
 #define M(n)           (Key){ KEY_FLAGS|SYNTHETIC|IS_MACRO, n}
 #define Key_macroKey1  M(1)

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -23,22 +23,18 @@ static void handle_mouse_key_event(Key mappedKey, uint8_t keyState) {
 }
 
 static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (! (mappedKey.flags & IS_INTERNAL)
-            && (mappedKey.rawKey == KEY_MOUSE_BTN_L
-                || mappedKey.rawKey == KEY_MOUSE_BTN_M
-                || mappedKey.rawKey == KEY_MOUSE_BTN_R)) {
-        if (key_toggled_on(keyState)) {
-            MouseWrapper.press_button(mappedKey.rawKey);
-        } else if (key_toggled_off(keyState)) {
-            MouseWrapper.release_button(mappedKey.rawKey);
-        }
-        return true;
-    }
-
-    if (!(mappedKey.flags & IS_MOUSE_KEY))
+    if (mappedKey.flags != (SYNTHETIC | IS_MOUSE_KEY))
         return false;
 
-    if (!(mappedKey.rawKey & KEY_MOUSE_WARP)) {
+    if (mappedKey.rawKey & KEY_MOUSE_BUTTON) {
+        uint8_t button = mappedKey.rawKey & ~KEY_MOUSE_BUTTON;
+
+        if (key_toggled_on(keyState)) {
+            MouseWrapper.press_button(button);
+        } else if (key_toggled_off(keyState)) {
+            MouseWrapper.release_button(button);
+        }
+    } else if (!(mappedKey.rawKey & KEY_MOUSE_WARP)) {
         handle_mouse_key_event(mappedKey, keyState);
     } else if (key_toggled_on(keyState)) {
         if (mappedKey.rawKey & KEY_MOUSE_WARP && mappedKey.flags & IS_MOUSE_KEY) {

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -54,5 +54,11 @@ static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState)
 }
 
 MouseKeys_::MouseKeys_(void) {
+}
+
+void
+MouseKeys_::begin (void) {
     event_handler_hook_add (handleMouseKeys);
 }
+
+MouseKeys_ MouseKeys;

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
@@ -3,9 +3,11 @@
 #include "KeyboardioFirmware.h"
 #include "MouseKeyDefs.h"
 
-class MouseKeys_ {
+class MouseKeys_ : public KeyboardioPlugin {
   public:
     MouseKeys_ (void);
+
+    virtual void begin(void) final;
 };
 
-static MouseKeys_ MouseKeys;
+extern MouseKeys_ MouseKeys;

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -5,14 +5,14 @@
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key
 #define KEY_MOUSE_BTN_M 0x02 // Synthetic key
-#define KEY_MOUSE_BTN_R 0x04 // Synthetic key
+#define KEY_MOUSE_BTN_R 0x03 // Synthetic key
 
 
 #define KEY_MOUSE_UP            B0000001
 #define KEY_MOUSE_DOWN          B0000010
 #define KEY_MOUSE_LEFT          B0000100
 #define KEY_MOUSE_RIGHT         B0001000
-#define KEY_MOUSE_CENTER        B0010000
+#define KEY_MOUSE_BUTTON        B0010000
 #define KEY_MOUSE_WARP          B0100000
 #define KEY_MOUSE_WARP_END      B1000000
 
@@ -36,6 +36,6 @@
 #define Key_mouseScrollDn
 #define Key_mouseScrollL
 #define Key_mouseScrollR
-#define Key_mouseBtnL    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_L }
-#define Key_mouseBtnM    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_M }
-#define Key_mouseBtnR    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_R }
+#define Key_mouseBtnL    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_L }
+#define Key_mouseBtnM    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_M }
+#define Key_mouseBtnR    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_R }

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MOUSE_KEY     		   B00010000
+#define IS_MOUSE_KEY     		   B00000010
 
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MOUSE_KEY     		   B00000010
+#define IS_MOUSE_KEY     		   B00010000
 
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -1,4 +1,5 @@
 #include "KeyboardioFirmware.h"
+#include <stdarg.h>
 
 Keyboardio_::Keyboardio_(void) {
     memset(eventHandlers, 0, HOOK_MAX * sizeof(custom_handler_t));
@@ -7,7 +8,6 @@ Keyboardio_::Keyboardio_(void) {
 
 void
 Keyboardio_::setup(const byte keymap_count) {
-    event_handler_hook_add (handle_key_event_default);
     wdt_disable();
     delay(100);
     Keyboard.begin();
@@ -15,6 +15,8 @@ Keyboardio_::setup(const byte keymap_count) {
     LEDControl.setup();
 
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
+
+    event_handler_hook_add (handle_key_event_default);
 }
 
 custom_loop_t loopHooks[HOOK_MAX];
@@ -32,3 +34,15 @@ Keyboardio_::loop(void) {
     }
 }
 
+void
+Keyboardio_::use(KeyboardioPlugin *plugin, ...) {
+    va_list ap;
+    KeyboardioPlugin *p;
+
+    plugin->begin();
+    va_start(ap, plugin);
+    while ((p = va_arg(ap, KeyboardioPlugin*)) != NULL) {
+      p->begin();
+    };
+    va_end(ap);
+}

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -15,8 +15,6 @@ Keyboardio_::setup(const byte keymap_count) {
     LEDControl.setup();
 
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
-
-    event_handler_hook_add (handle_key_event_default);
 }
 
 custom_loop_t loopHooks[HOOK_MAX];

--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -23,6 +23,7 @@ void setup();
 
 #include "KeyboardConfig.h"
 #include "key_events.h"
+#include "plugin.h"
 
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
@@ -41,6 +42,7 @@ class Keyboardio_ {
 
     void setup(const byte keymap_count);
     void loop(void);
+    void use(KeyboardioPlugin *plugin, ...);
 };
 
 static Keyboardio_ Keyboardio;

--- a/src/LED-BreatheEffect.cpp
+++ b/src/LED-BreatheEffect.cpp
@@ -1,14 +1,14 @@
 #include "LED-BreatheEffect.h"
 
-LEDBreatheEffect::LEDBreatheEffect (void) {
+LEDBreatheEffect_::LEDBreatheEffect_ (void) {
   state.brightness = 0;
   state.fadeAmount = 1;
-
-  LEDControl.mode_add (this);
 }
 
 void
-LEDBreatheEffect::update (void) {
+LEDBreatheEffect_::update (void) {
   cRGB color = breath_compute (&state);
   LEDControl.set_all_leds_to (color);
 }
+
+LEDBreatheEffect_ LEDBreatheEffect;

--- a/src/LED-BreatheEffect.h
+++ b/src/LED-BreatheEffect.h
@@ -3,12 +3,14 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDBreatheEffect : LEDMode {
+class LEDBreatheEffect_ : LEDMode {
  public:
-  LEDBreatheEffect (void);
+  LEDBreatheEffect_ (void);
 
   virtual void update (void) final;
 
  private:
   BreathState state;
 };
+
+extern LEDBreatheEffect_ LEDBreatheEffect;

--- a/src/LED-ChaseEffect.cpp
+++ b/src/LED-ChaseEffect.cpp
@@ -1,11 +1,10 @@
 #include "LED-ChaseEffect.h"
 
-LEDChaseEffect::LEDChaseEffect (void) {
-  LEDControl.mode_add (this);
+LEDChaseEffect_::LEDChaseEffect_ (void) {
 }
 
 void
-LEDChaseEffect::update (void) {
+LEDChaseEffect_::update (void) {
   if (current_chase_counter++ < chase_threshold) {
     return;
   }
@@ -20,3 +19,5 @@ LEDChaseEffect::update (void) {
   led_set_crgb_at(pos, {0, 0, 255});
   led_set_crgb_at(pos - (chase_sign * chase_pixels), {255, 0, 0});
 }
+
+LEDChaseEffect_ LEDChaseEffect;

--- a/src/LED-ChaseEffect.h
+++ b/src/LED-ChaseEffect.h
@@ -3,9 +3,9 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDChaseEffect : LEDMode {
+class LEDChaseEffect_ : LEDMode {
  public:
-  LEDChaseEffect (void);
+  LEDChaseEffect_ (void);
 
   virtual void update (void) final;
 
@@ -16,3 +16,5 @@ class LEDChaseEffect : LEDMode {
   uint8_t current_chase_counter = 0;
   static const uint8_t chase_threshold = 20;
 };
+
+extern LEDChaseEffect_ LEDChaseEffect;

--- a/src/LED-Numlock.cpp
+++ b/src/LED-Numlock.cpp
@@ -7,11 +7,15 @@ static uint8_t us;
 
 LEDNumlock::LEDNumlock (uint8_t numpadIdx) {
   numpadIndex = numpadIdx;
-  us = LEDControl.mode_add (this);
-  loop_hook_add (this->loopHook);
 
   breathState.brightness = 0;
   breathState.fadeAmount = 1;
+}
+
+void
+LEDNumlock::begin (void) {
+  us = LEDControl.mode_add (this);
+  loop_hook_add (this->loopHook);
 }
 
 void

--- a/src/LED-Numlock.h
+++ b/src/LED-Numlock.h
@@ -7,6 +7,8 @@ class LEDNumlock : LEDMode {
  public:
   LEDNumlock (uint8_t numpadIndex);
 
+  virtual void begin (void) final;
+
   virtual void update (void) final;
   virtual void setup (void) final;
 

--- a/src/LED-Off.cpp
+++ b/src/LED-Off.cpp
@@ -1,0 +1,3 @@
+#include "LED-Off.h"
+
+LEDOff_ LEDOff;

--- a/src/LED-Off.h
+++ b/src/LED-Off.h
@@ -2,7 +2,9 @@
 
 #include "LEDControl.h"
 
-class LEDOff : LEDMode {
+class LEDOff_ : public LEDMode {
  public:
-  LEDOff (void) { LEDControl.mode_add (this); };
+  LEDOff_ (void) { };
 };
+
+extern LEDOff_ LEDOff;

--- a/src/LED-RainbowEffect.cpp
+++ b/src/LED-RainbowEffect.cpp
@@ -1,11 +1,10 @@
 #include "LED-RainbowEffect.h"
 
-LEDRainbowEffect::LEDRainbowEffect (void) {
-  LEDControl.mode_add (this);
+LEDRainbowEffect_::LEDRainbowEffect_ (void) {
 }
 
 void
-LEDRainbowEffect::update (void) {
+LEDRainbowEffect_::update (void) {
   if (rainbow_current_ticks++ < rainbow_ticks) {
     return;
   } else {
@@ -21,14 +20,15 @@ LEDRainbowEffect::update (void) {
   LEDControl.set_all_leds_to(rainbow);
 }
 
+LEDRainbowEffect_ LEDRainbowEffect;
+
 // ---------
 
-LEDRainbowWaveEffect::LEDRainbowWaveEffect (void) {
-  LEDControl.mode_add (this);
+LEDRainbowWaveEffect_::LEDRainbowWaveEffect_ (void) {
 }
 
 void
-LEDRainbowWaveEffect::update (void) {
+LEDRainbowWaveEffect_::update (void) {
   if (rainbow_current_ticks++ < rainbow_wave_ticks) {
     return;
   } else {
@@ -48,3 +48,5 @@ LEDRainbowWaveEffect::update (void) {
     rainbow_hue -= 255;
   }
 }
+
+LEDRainbowWaveEffect_ LEDRainbowWaveEffect;

--- a/src/LED-RainbowEffect.h
+++ b/src/LED-RainbowEffect.h
@@ -3,9 +3,9 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDRainbowEffect : LEDMode {
+class LEDRainbowEffect_ : LEDMode {
  public:
-  LEDRainbowEffect (void);
+  LEDRainbowEffect_ (void);
 
   virtual void update (void) final;
 
@@ -21,9 +21,11 @@ class LEDRainbowEffect : LEDMode {
 
 };
 
-class LEDRainbowWaveEffect : LEDMode {
+extern LEDRainbowEffect_ LEDRainbowEffect;
+
+class LEDRainbowWaveEffect_ : LEDMode {
  public:
-  LEDRainbowWaveEffect (void);
+  LEDRainbowWaveEffect_ (void);
 
   virtual void update (void) final;
 
@@ -37,3 +39,5 @@ class LEDRainbowWaveEffect : LEDMode {
   static const byte rainbow_saturation = 255;
   static const byte rainbow_value = 50;
 };
+
+extern LEDRainbowWaveEffect_ LEDRainbowWaveEffect;

--- a/src/LEDControl.cpp
+++ b/src/LEDControl.cpp
@@ -5,6 +5,11 @@ LEDMode::activate (void) {
   LEDControl.activate (this);
 }
 
+void
+LEDMode::begin(void) {
+  LEDControl.mode_add(this);
+}
+
 LEDControl_::LEDControl_(void) {
   memset (modes, 0, LED_MAX_MODES * sizeof (modes[0]));
 }

--- a/src/LEDControl.h
+++ b/src/LEDControl.h
@@ -2,11 +2,13 @@
 
 #include <Arduino.h>
 #include "KeyboardConfig.h"
+#include "plugin.h"
 
 #define LED_MAX_MODES 24
 
-class LEDMode {
+class LEDMode : public KeyboardioPlugin {
  public:
+  virtual void begin (void);
   virtual void setup (void) {};
   virtual void init (void) {};
   virtual void update (void) {};

--- a/src/TestMode.cpp
+++ b/src/TestMode.cpp
@@ -2,8 +2,6 @@
 #include "TestMode.h"
 #include "LED-RainbowEffect.h"
 
-static LEDRainbowEffect testRainbowEffect;
-
 cRGB red;
 cRGB blue;
 
@@ -47,7 +45,7 @@ void TestMode_::TestLEDs(void) {
     delay(LED_TEST_DELAY);
     // rainbow for 10 seconds
     for(auto i=0; i<1000; i++ ) {
-        testRainbowEffect.update();
+        LEDRainbowEffect.update();
         led_sync();
     }
     // set all the keys to red

--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -19,7 +19,8 @@ typedef union {
 #define RALT_HELD         B00000100
 #define SHIFT_HELD        B00001000
 #define GUI_HELD          B00010000
-#define SYNTHETIC         B10000000
+#define SYNTHETIC         B01000000
+#define RESERVED          B10000000
 
 #define LCTRL(k)  ((Key) { k.flags | CTRL_HELD, k.rawKey })
 #define LALT(k)   ((Key) { k.flags | LALT_HELD, k.rawKey })
@@ -28,16 +29,15 @@ typedef union {
 #define LGUI(k)   ((Key) { k.flags | GUI_HELD, k.rawKey })
 
 // we assert that synthetic keys can never have keys held, so we reuse the _HELD bits
-#define IS_SYSCTL        B00000010
-#define IS_CONSUMER      B00000100
-#define IS_INTERNAL      B00001000
-#define SWITCH_TO_KEYMAP 		   B00100000
-#define SWITCH_TO_KEYMAP_MOMENTARY         B01000000
-
+#define IS_SYSCTL                  B00000001
+#define IS_CONSUMER                B00000010
+#define SWITCH_TO_KEYMAP 		       B00000100
+#define SWITCH_TO_KEYMAP_MOMENTARY B00001000
+#define IS_INTERNAL                B00010000
 
 // IS_INTERNAL key table:
 
-#define LED_TOGGLE  0x01 // Synthetic, internal
+#define LED_TOGGLE   B00000001 // Synthetic, internal
 
 
 #define KEYMAP_0     0
@@ -253,4 +253,4 @@ typedef union {
 
 
 
-#define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL, LED_TOGGLE }
+#define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE, 0 }

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -60,18 +60,7 @@ Key lookup_key(byte keymap, byte row, byte col) {
     return mappedKey;
 }
 
-void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (!(keyState & INJECTED)) {
-        mappedKey = lookup_key(temporary_keymap, row, col);
-    }
-    for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
-        custom_handler_t handler = eventHandlers[i];
-        if ((*handler)(mappedKey, row, col, keyState))
-            return;
-    }
-}
-
-bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState) {
+static bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState) {
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
 
@@ -130,4 +119,16 @@ void release_key(Key mappedKey) {
         Keyboard.release(Key_LGUI.rawKey);
     }
     Keyboard.release(mappedKey.rawKey);
+}
+
+void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
+    if (!(keyState & INJECTED)) {
+        mappedKey = lookup_key(temporary_keymap, row, col);
+    }
+    for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
+        custom_handler_t handler = eventHandlers[i];
+        if ((*handler)(mappedKey, row, col, keyState))
+            return;
+    }
+    handle_key_event_default(mappedKey, row, col, keyState);
 }

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -48,6 +48,5 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState);
 // Internal use
 void press_key(Key mappedKey);
 void release_key(Key mappedKey);
-bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 Key lookup_key(byte keymap, byte row, byte col);

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -46,10 +46,8 @@ extern const Key keymaps[][ROWS][COLS];
 void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 // Internal use
-void handle_synthetic_key_event( Key mappedKey, uint8_t keyState);
 void press_key(Key mappedKey);
 void release_key(Key mappedKey);
-void handle_keymap_key_event(Key keymapEntry, uint8_t keyState);
 bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 Key lookup_key(byte keymap, byte row, byte col);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class KeyboardioPlugin {
+ public:
+  virtual void begin(void) = 0;
+};
+


### PR DESCRIPTION
Please see the individual commit messages. The gist of the story is that adding elements to the hook arrays from constructors does not work. So this patchset introduces another - sadly uglier - method of achieving the same thing. One that guarantees better ordering.

With these patches applied, macros, layers, and mouse keys all work.

I was not able to test warp yet, but I made sure that the function is called. It just doesn't do anything, but that may be on my end.