### PR TITLE
Hook rework part #2

### DIFF
--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -24,7 +24,6 @@ uint8_t temporary_keymap = 0;
 
 const Key keymaps[][ROWS][COLS] PROGMEM = { KEYMAP_LIST };
 
-static LEDOff LEDSOff;
 static LEDSolidColor solidRed (100, 0, 0);
 static LEDSolidColor solidOrange (100, 30, 0);
 static LEDSolidColor solidYellow (90, 70, 0);
@@ -32,11 +31,6 @@ static LEDSolidColor solidGreen (0, 200, 0);
 static LEDSolidColor solidBlue (0, 30, 200);
 static LEDSolidColor solidIndigo (0, 0, 200);
 static LEDSolidColor solidViolet (100, 0, 120);
-
-static LEDBreatheEffect breatheEffect;
-static LEDRainbowEffect rainbowEffect;
-static LEDRainbowWaveEffect rainbowWaveEffect;
-static LEDChaseEffect chaseEffect;
 
 static LEDNumlock numLockEffect (NUMPAD_KEYMAP);
 
@@ -54,7 +48,16 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 }
 
 void setup() {
+    Keyboardio.use(&LEDOff,
+                   &solidRed, &solidOrange, &solidYellow, &solidGreen, &solidBlue, &solidIndigo, &solidViolet,
+                   &LEDBreatheEffect, &LEDRainbowEffect, &LEDChaseEffect, &numLockEffect,
+
+                   &Macros,
+                   &MouseKeys,
+                   NULL);
+
     Keyboardio.setup(KEYMAP_SIZE);
+    LEDOff.activate();
 }
 
 

--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -48,6 +48,8 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 }
 
 void setup() {
+    Keyboardio.setup(KEYMAP_SIZE);
+
     Keyboardio.use(&LEDOff,
                    &solidRed, &solidOrange, &solidYellow, &solidGreen, &solidBlue, &solidIndigo, &solidViolet,
                    &LEDBreatheEffect, &LEDRainbowEffect, &LEDChaseEffect, &numLockEffect,
@@ -56,7 +58,6 @@ void setup() {
                    &MouseKeys,
                    NULL);
 
-    Keyboardio.setup(KEYMAP_SIZE);
     LEDOff.activate();
 }
 

--- a/examples/KeyboardioFirmware/generated/keymaps.h
+++ b/examples/KeyboardioFirmware/generated/keymaps.h
@@ -10,10 +10,10 @@
 	{Key_PageDn, Key_Semicolon, Key_Q, Key_J, Key_K, Key_X, Key_Esc, Key_Keymap2, Key_B, Key_M, Key_W, Key_V, Key_Z, Key_Equals},\
 	{Key_LCtrl, Key_Backspace, Key_LShift, Key_LGUI, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RAlt, Key_RShift, Key_Space, Key_RCtrl},\
 },
-#define KEYMAP_GENERIC_FN2 { /* Generated keymap for GENERIC_FN2 */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Trans, Key_skip},\
-	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LSquareBracket, Key_RSquareBracket, Key_sleep},\
+#define KEYMAP_GENERIC_FN2 { /* Generated keymap for GENERIC_FN2 */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, XXX, Key_LCtrl, Key_RCtrl, XXX, Key_F6, Key_F7, Key_F8, Key_F9, ___, Key_skip},\
+	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, XXX, Key_mouseBtnL, Key_mouseBtnR, XXX, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LSquareBracket, Key_RSquareBracket, Key_sleep},\
 	{Key_Home, Key_mouseL, Key_mouseDn, Key_mouseR, Key_mouseWarpSW, Key_mouseWarpSE, Key_nextTrack, Key_LGUI, Key_RAlt, Key_Delete, Key_LArrow, Key_DnArrow, Key_UpArrow, Key_RArrow, Key_F11, Key_F12},\
-	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, Key_Trans, Key_LShift, Key_RShift, Key_Trans, Key_volumeDown, Key_volumeUp, Key_BacklightDn, Key_BacklightUp, Key_Backslash, Key_Pipe},\
+	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, ___, Key_LShift, Key_RShift, ___, Key_volumeDown, Key_volumeUp, Key_BacklightDn, Key_BacklightUp, Key_Backslash, Key_Pipe},\
 },
 #define KEYMAP_GENERIC_FN2_MOO { /* Generated keymap for GENERIC_FN2_MOO */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Keymap0, Key_skip},\
 	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LEFT_PAREN, Key_RIGHT_PAREN, Key_sleep},\
@@ -26,10 +26,10 @@
 	{Key_PageDn, Key_Comma, Key_Period, Key_J, Key_G, Key_Slash, Key_Esc, Key_Keymap2, Key_Semicolon, Key_W, Key_K, Key_Minus, Key_X, Key_LSquareBracket},\
 	{Key_LGUI, Key_E, Key_LShift, Key_Backspace, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RCtrl, Key_RShift, Key_Space, Key_RAlt},\
 },
-#define KEYMAP_NUMPAD { /* Generated keymap for NUMPAD */ 	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad7, Key_Keypad8, Key_Keypad9, Key_KeypadMinus, Key_Trans},\
-	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keymap1_Momentary, Key_Trans, Key_Trans, Key_Keymap1_Momentary, Key_Trans, Key_Keypad4, Key_Keypad5, Key_Keypad6, Key_KeypadPlus, Key_Trans},\
-	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
-	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
+#define KEYMAP_NUMPAD { /* Generated keymap for NUMPAD */ 	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad7, Key_Keypad8, Key_Keypad9, Key_KeypadMinus, ___},\
+	{___, ___, ___, ___, ___, ___, Key_Keymap1_Momentary, ___, ___, Key_Keymap1_Momentary, ___, Key_Keypad4, Key_Keypad5, Key_Keypad6, Key_KeypadPlus, ___},\
+	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
+	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
 },
 #define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
 	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab, Key_Backspace, Key_Space, Key_Enter, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\

--- a/examples/KeyboardioFirmware/generated/keymaps.h
+++ b/examples/KeyboardioFirmware/generated/keymaps.h
@@ -1,13 +1,8 @@
-#define KEYMAP_GENERIC_FN2_MOO { /* Generated keymap for GENERIC_FN2_MOO */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Keymap0, Key_skip},\
-	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LEFT_PAREN, Key_RIGHT_PAREN, Key_sleep},\
-	{Key_Home, Key_mouseL, Key_mouseDn, Key_mouseR, Key_mouseWarpSW, Key_mouseWarpSE, Key_nextTrack, Key_LShift, Key_RShift, Key_Delete, Key_LArrow, Key_DnArrow, Key_UpArrow, Key_RArrow, Key_F11, Key_F12},\
-	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, Key_skip, Key_LGUI, Key_RAlt, Key_skip, Key_volumeDown, Key_volumeUp, Key_LSquareBracket, Key_RSquareBracket, Key_Backslash, Key_Pipe},\
-},
-#define KEYMAP_WORKMAN { /* Generated keymap for WORKMAN */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
-	{Key_Backtick, Key_Q, Key_D, Key_R, Key_W, Key_B, Key_skip, Key_skip, Key_J, Key_F, Key_U, Key_P, Key_Semicolon, Key_Equals},\
-	{Key_PageUp, Key_A, Key_S, Key_H, Key_T, Key_G, Key_Tab, Key_Return, Key_Y, Key_N, Key_E, Key_O, Key_I, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_M, Key_C, Key_V, Key_Esc, Key_Keymap0, Key_K, Key_L, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
-	{Key_LGUI, Key_Backspace, Key_LShift, Key_LCtrl, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RCtrl, Key_RShift, Key_Space, Key_RAlt},\
+#define KEYMAP_COLEMAK { /* Generated keymap for COLEMAK */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
+	{Key_Backtick, Key_Q, Key_W, Key_F, Key_P, Key_G, Key_skip, Key_skip, Key_J, Key_L, Key_U, Key_Y, Key_Semicolon, Key_Equals},\
+	{Key_PageUp, Key_A, Key_R, Key_S, Key_T, Key_D, Key_Tab, Key_Return, Key_H, Key_N, Key_E, Key_I, Key_O, Key_Quote},\
+	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_Keymap2, Key_K, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+	{Key_LCtrl, Key_Backspace, Key_LShift, Key_LGUI, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RAlt, Key_RShift, Key_Space, Key_RCtrl},\
 },
 #define KEYMAP_DVORAK { /* Generated keymap for DVORAK */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
 	{Key_Backtick, Key_Quote, Key_Comma, Key_Period, Key_P, Key_Y, Key_skip, Key_skip, Key_F, Key_G, Key_C, Key_R, Key_L, Key_Slash},\
@@ -15,31 +10,15 @@
 	{Key_PageDn, Key_Semicolon, Key_Q, Key_J, Key_K, Key_X, Key_Esc, Key_Keymap2, Key_B, Key_M, Key_W, Key_V, Key_Z, Key_Equals},\
 	{Key_LCtrl, Key_Backspace, Key_LShift, Key_LGUI, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RAlt, Key_RShift, Key_Space, Key_RCtrl},\
 },
-#define KEYMAP_NUMPAD { /* Generated keymap for NUMPAD */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_Keypad7, Key_Keypad8, Key_Keypad9, Key_KeypadMinus, Key_Keymap0},\
-	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Keymap1_Momentary, Key_Backspace, Key_Space, Key_Keymap1_Momentary, Key_Y, Key_Keypad4, Key_Keypad5, Key_Keypad6, Key_KeypadPlus, Key_Equals},\
-	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LGUI, Key_RAlt, Key_Return, Key_H, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_LShift, Key_RShift, Key_skip, Key_N, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
+#define KEYMAP_GENERIC_FN2 { /* Generated keymap for GENERIC_FN2 */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Trans, Key_skip},\
+	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LSquareBracket, Key_RSquareBracket, Key_sleep},\
+	{Key_Home, Key_mouseL, Key_mouseDn, Key_mouseR, Key_mouseWarpSW, Key_mouseWarpSE, Key_nextTrack, Key_LGUI, Key_RAlt, Key_Delete, Key_LArrow, Key_DnArrow, Key_UpArrow, Key_RArrow, Key_F11, Key_F12},\
+	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, Key_Trans, Key_LShift, Key_RShift, Key_Trans, Key_volumeDown, Key_volumeUp, Key_BacklightDn, Key_BacklightUp, Key_Backslash, Key_Pipe},\
 },
-#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
-	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab, Key_Backspace, Key_Space, Key_Enter, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
-	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Esc, Key_LGUI, Key_RAlt, Key_skip, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_KeymapNext_Momentary, Key_LShift, Key_RShift, Key_KeymapNext_Momentary, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
-},
-#define KEYMAP_COLEMAK { /* Generated keymap for COLEMAK */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
-	{Key_Backtick, Key_Q, Key_W, Key_F, Key_P, Key_G, Key_skip, Key_skip, Key_J, Key_L, Key_U, Key_Y, Key_Semicolon, Key_Equals},\
-	{Key_PageUp, Key_A, Key_R, Key_S, Key_T, Key_D, Key_Tab, Key_Return, Key_H, Key_N, Key_E, Key_I, Key_O, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_Keymap2, Key_K, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
-	{Key_LCtrl, Key_Backspace, Key_LShift, Key_LGUI, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RAlt, Key_RShift, Key_Space, Key_RCtrl},\
-},
-#define KEYMAP_QWERTY_PIERS { /* Generated keymap for QWERTY_PIERS */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
-	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_KeymapNext_Momentary, Key_Backspace, Key_Space, Key_KeymapNext_Momentary, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
-	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LGUI, Key_RAlt, Key_Return, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_RShift, Key_RShift, Key_skip, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
-},
-#define KEYMAP_QWERTY_ALT_CMD { /* Generated keymap for QWERTY_ALT_CMD */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
-	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_KeymapNext_Momentary, Key_Backspace, Key_Space, Key_KeymapNext_Momentary, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
-	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LAlt, Key_RGUI, Key_Return, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
-	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_LShift, Key_RShift, Key_skip, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+#define KEYMAP_GENERIC_FN2_MOO { /* Generated keymap for GENERIC_FN2_MOO */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Keymap0, Key_skip},\
+	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LEFT_PAREN, Key_RIGHT_PAREN, Key_sleep},\
+	{Key_Home, Key_mouseL, Key_mouseDn, Key_mouseR, Key_mouseWarpSW, Key_mouseWarpSE, Key_nextTrack, Key_LShift, Key_RShift, Key_Delete, Key_LArrow, Key_DnArrow, Key_UpArrow, Key_RArrow, Key_F11, Key_F12},\
+	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, Key_skip, Key_LGUI, Key_RAlt, Key_skip, Key_volumeDown, Key_volumeUp, Key_LSquareBracket, Key_RSquareBracket, Key_Backslash, Key_Pipe},\
 },
 #define KEYMAP_MALTRON { /* Generated keymap for MALTRON */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
 	{Key_Backtick, Key_Q, Key_P, Key_Y, Key_C, Key_B, Key_skip, Key_skip, Key_V, Key_M, Key_U, Key_Z, Key_L, Key_Equals},\
@@ -47,13 +26,34 @@
 	{Key_PageDn, Key_Comma, Key_Period, Key_J, Key_G, Key_Slash, Key_Esc, Key_Keymap2, Key_Semicolon, Key_W, Key_K, Key_Minus, Key_X, Key_LSquareBracket},\
 	{Key_LGUI, Key_E, Key_LShift, Key_Backspace, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RCtrl, Key_RShift, Key_Space, Key_RAlt},\
 },
+#define KEYMAP_NUMPAD { /* Generated keymap for NUMPAD */ 	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad7, Key_Keypad8, Key_Keypad9, Key_KeypadMinus, Key_Trans},\
+	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keymap1_Momentary, Key_Trans, Key_Trans, Key_Keymap1_Momentary, Key_Trans, Key_Keypad4, Key_Keypad5, Key_Keypad6, Key_KeypadPlus, Key_Trans},\
+	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
+	{Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Trans, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
+},
+#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
+	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab, Key_Backspace, Key_Space, Key_Enter, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
+	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Esc, Key_LGUI, Key_RAlt, Key_skip, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
+	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_KeymapNext_Momentary, Key_LShift, Key_RShift, Key_KeymapNext_Momentary, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+},
+#define KEYMAP_QWERTY_ALT_CMD { /* Generated keymap for QWERTY_ALT_CMD */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
+	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_KeymapNext_Momentary, Key_Backspace, Key_Space, Key_KeymapNext_Momentary, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
+	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LAlt, Key_RGUI, Key_Return, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
+	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_LShift, Key_RShift, Key_skip, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+},
 #define KEYMAP_QWERTY_MOO { /* Generated keymap for QWERTY_MOO */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
 	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_KeymapNext_Momentary, Key_Backspace, Key_Space, Key_KeymapNext_Momentary, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
 	{Key_Backslash, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LShift, Key_RShift, Key_Return, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
 	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_LGUI, Key_RAlt, Key_skip, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
 },
-#define KEYMAP_GENERIC_FN2 { /* Generated keymap for GENERIC_FN2 */ 	{Key_skip, Key_F1, Key_F2, Key_F3, Key_F4, Key_F5, Key_NoKey, Key_LCtrl, Key_RCtrl, Key_NoKey, Key_F6, Key_F7, Key_F8, Key_F9, Key_Keymap0, Key_skip},\
-	{Key_Tab, Key_mouseBtnM, Key_mouseUp, Key_skip, Key_mouseWarpNW, Key_mouseWarpNE, Key_NoKey, Key_mouseBtnL, Key_mouseBtnR, Key_NoKey, Key_playPause, Key_LCurlyBracket, Key_RCurlyBracket, Key_LSquareBracket, Key_RSquareBracket, Key_sleep},\
-	{Key_Home, Key_mouseL, Key_mouseDn, Key_mouseR, Key_mouseWarpSW, Key_mouseWarpSE, Key_nextTrack, Key_LGUI, Key_RAlt, Key_Delete, Key_LArrow, Key_DnArrow, Key_UpArrow, Key_RArrow, Key_F11, Key_F12},\
-	{Key_End, Key_Z, Key_X, Key_C, Key_V, Key_mouseWarpEnd, Key_skip, Key_LShift, Key_RShift, Key_skip, Key_volumeDown, Key_volumeUp, Key_BacklightDn, Key_BacklightUp, Key_Backslash, Key_Pipe},\
+#define KEYMAP_QWERTY_PIERS { /* Generated keymap for QWERTY_PIERS */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
+	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_KeymapNext_Momentary, Key_Backspace, Key_Space, Key_KeymapNext_Momentary, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
+	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Tab, Key_LGUI, Key_RAlt, Key_Return, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
+	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc, Key_RShift, Key_RShift, Key_skip, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+},
+#define KEYMAP_WORKMAN { /* Generated keymap for WORKMAN */ 	{Key_skip, Key_1, Key_2, Key_3, Key_4, Key_5, Key_skip, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_skip},\
+	{Key_Backtick, Key_Q, Key_D, Key_R, Key_W, Key_B, Key_skip, Key_skip, Key_J, Key_F, Key_U, Key_P, Key_Semicolon, Key_Equals},\
+	{Key_PageUp, Key_A, Key_S, Key_H, Key_T, Key_G, Key_Tab, Key_Return, Key_Y, Key_N, Key_E, Key_O, Key_I, Key_Quote},\
+	{Key_PageDn, Key_Z, Key_X, Key_M, Key_C, Key_V, Key_Esc, Key_Keymap0, Key_K, Key_L, Key_Comma, Key_Period, Key_Slash, Key_Minus},\
+	{Key_LGUI, Key_Backspace, Key_LShift, Key_LCtrl, Key_KeymapNext_Momentary, Key_skip, Key_skip, Key_skip, Key_skip, Key_KeymapNext_Momentary, Key_RCtrl, Key_RShift, Key_Space, Key_RAlt},\
 },

--- a/examples/KeyboardioFirmware/layouts/generic_fn2
+++ b/examples/KeyboardioFirmware/layouts/generic_fn2
@@ -1,5 +1,5 @@
 #NAME: GENERIC_FN2
-skip   F1        F2        F3      F4           F5            NoKey     LCtrl       RCtrl       NoKey      F6          F7        F8          F9           Keymap0      skip  
+skip   F1        F2        F3      F4           F5            NoKey     LCtrl       RCtrl       NoKey      F6          F7        F8          F9           Trans        skip  
 Tab    mouseBtnM mouseUp   skip    mouseWarpNW  mouseWarpNE   NoKey     mouseBtnL   mouseBtnR   NoKey      playPause   {         }           [            ]        sleep
 Home   mouseL 	 mouseDn   mouseR  mouseWarpSW  mouseWarpSE   nextTrack LGUI        RAlt        Delete     LArrow      DnArrow   UpArrow     RArrow       F11      F12
-End    Z         X         C       V            mouseWarpEnd  skip      LShift      RShift      skip       volumeDown  volumeUp  BacklightDn BacklightUp  \        |
+End    Z         X         C       V            mouseWarpEnd  Trans     LShift      RShift      Trans      volumeDown  volumeUp  BacklightDn BacklightUp  \        |

--- a/examples/KeyboardioFirmware/layouts/generic_fn2
+++ b/examples/KeyboardioFirmware/layouts/generic_fn2
@@ -1,5 +1,5 @@
 #NAME: GENERIC_FN2
-skip   F1        F2        F3      F4           F5            NoKey     LCtrl       RCtrl       NoKey      F6          F7        F8          F9           Trans        skip  
-Tab    mouseBtnM mouseUp   skip    mouseWarpNW  mouseWarpNE   NoKey     mouseBtnL   mouseBtnR   NoKey      playPause   {         }           [            ]        sleep
+skip   F1        F2        F3      F4           F5            XXXXXXXXX LCtrl       RCtrl       XXXXXX     F6          F7        F8          F9           ___      skip
+Tab    mouseBtnM mouseUp   skip    mouseWarpNW  mouseWarpNE   XXXXXXXXX mouseBtnL   mouseBtnR   XXXXXX     playPause   {         }           [            ]        sleep
 Home   mouseL 	 mouseDn   mouseR  mouseWarpSW  mouseWarpSE   nextTrack LGUI        RAlt        Delete     LArrow      DnArrow   UpArrow     RArrow       F11      F12
-End    Z         X         C       V            mouseWarpEnd  Trans     LShift      RShift      Trans      volumeDown  volumeUp  BacklightDn BacklightUp  \        |
+End    Z         X         C       V            mouseWarpEnd  _________ LShift      RShift      ______     volumeDown  volumeUp  BacklightDn BacklightUp  \        |

--- a/examples/KeyboardioFirmware/layouts/numpad
+++ b/examples/KeyboardioFirmware/layouts/numpad
@@ -1,5 +1,5 @@
 #NAME: NUMPAD
-LEDEffectNext   1 2 3 4 5  skip                 LCtrl       RCtrl 	  skip                  6 Keypad7 Keypad8   Keypad9         KeypadMinus Keymap0
-`               Q W E R T  Keymap1_Momentary    Backspace   Space     Keymap1_Momentary     Y Keypad4 Keypad5   Keypad6         KeypadPlus  =
-PageUp 	        A S D F G  Tab                  LGUI        RAlt	  Return                H Keypad1 Keypad2   Keypad3         Equals      '
-PageDn 	        Z X C V B  Esc                  LShift      RShift 	   skip                 N Keypad0 KeypadDot KeypadMultiply  KeypadSlash Enter 
+Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans 	Trans              Trans Keypad7 Keypad8   Keypad9         KeypadMinus Trans
+Trans  Trans Trans Trans Trans Trans  Keymap1_Momentary    Trans       Trans  Keymap1_Momentary  Trans Keypad4 Keypad5   Keypad6         KeypadPlus  Trans
+Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans  Trans              Trans Keypad1 Keypad2   Keypad3         Equals      '
+Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans  Trans              Trans Keypad0 KeypadDot KeypadMultiply  KeypadSlash Enter 

--- a/examples/KeyboardioFirmware/layouts/numpad
+++ b/examples/KeyboardioFirmware/layouts/numpad
@@ -1,5 +1,5 @@
 #NAME: NUMPAD
-Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans 	Trans              Trans Keypad7 Keypad8   Keypad9         KeypadMinus Trans
-Trans  Trans Trans Trans Trans Trans  Keymap1_Momentary    Trans       Trans  Keymap1_Momentary  Trans Keypad4 Keypad5   Keypad6         KeypadPlus  Trans
-Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans  Trans              Trans Keypad1 Keypad2   Keypad3         Equals      '
-Trans  Trans Trans Trans Trans Trans  Trans                Trans       Trans  Trans              Trans Keypad0 KeypadDot KeypadMultiply  KeypadSlash Enter 
+___  ___ ___ ___ ___ ___  _________________  ___       ___ 	_________________ ___ Keypad7 Keypad8   Keypad9         KeypadMinus ___
+___  ___ ___ ___ ___ ___  Keymap1_Momentary  ___       ___  Keymap1_Momentary ___ Keypad4 Keypad5   Keypad6         KeypadPlus  ___
+___  ___ ___ ___ ___ ___  _________________  ___       ___  _________________ ___ Keypad1 Keypad2   Keypad3         Equals      '
+___  ___ ___ ___ ___ ___  _________________  ___       ___  _________________ ___ Keypad0 KeypadDot KeypadMultiply  KeypadSlash Enter

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -44,17 +44,17 @@ void Macros_::play(const macro_t *macro_p) {
     }
 }
 
-static bool handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
+static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
     if (mappedKey.flags != (SYNTHETIC | IS_MACRO))
-        return false;
+        return mappedKey;
 
     if (!key_toggled_on(keyState))
-      return true;
+      return Key_NoKey;
 
     const macro_t *m = macroAction(mappedKey.rawKey, keyState);
 
     Macros.play(m);
-    return true;
+    return Key_NoKey;
 }
 
 Macros_::Macros_ (void) {

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -45,8 +45,11 @@ void Macros_::play(const macro_t *macro_p) {
 }
 
 static bool handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (!(mappedKey.flags & (SYNTHETIC|IS_MACRO)) || (mappedKey.flags & IS_INTERNAL))
+    if (mappedKey.flags != (SYNTHETIC | IS_MACRO))
         return false;
+
+    if (!key_toggled_on(keyState))
+      return true;
 
     const macro_t *m = macroAction(mappedKey.rawKey, keyState);
 

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -55,5 +55,11 @@ static bool handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState
 }
 
 Macros_::Macros_ (void) {
+}
+
+void
+Macros_::begin (void) {
     event_handler_hook_add (handleMacroEvent);
 }
+
+Macros_ Macros;

--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.h
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.h
@@ -7,11 +7,13 @@
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
 
-class Macros_ {
+class Macros_ : public KeyboardioPlugin {
   public:
     Macros_(void);
+
+    virtual void begin(void) final;
 
     void play(const macro_t *macro_p);
 };
 
-static Macros_ Macros;
+extern Macros_ Macros;

--- a/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
+++ b/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MACRO       B00000001
+#define IS_MACRO       B00000100
 
 #define M(n)           (Key){ KEY_FLAGS|SYNTHETIC|IS_MACRO, n}
 #define Key_macroKey1  M(1)

--- a/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
+++ b/libraries/Keyboardio-Macros/src/MacroKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MACRO       B00000100
+#define IS_MACRO       B00100000
 
 #define M(n)           (Key){ KEY_FLAGS|SYNTHETIC|IS_MACRO, n}
 #define Key_macroKey1  M(1)

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -23,22 +23,18 @@ static void handle_mouse_key_event(Key mappedKey, uint8_t keyState) {
 }
 
 static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (! (mappedKey.flags & IS_INTERNAL)
-            && (mappedKey.rawKey == KEY_MOUSE_BTN_L
-                || mappedKey.rawKey == KEY_MOUSE_BTN_M
-                || mappedKey.rawKey == KEY_MOUSE_BTN_R)) {
-        if (key_toggled_on(keyState)) {
-            MouseWrapper.press_button(mappedKey.rawKey);
-        } else if (key_toggled_off(keyState)) {
-            MouseWrapper.release_button(mappedKey.rawKey);
-        }
-        return true;
-    }
-
-    if (!(mappedKey.flags & IS_MOUSE_KEY))
+    if (mappedKey.flags != (SYNTHETIC | IS_MOUSE_KEY))
         return false;
 
-    if (!(mappedKey.rawKey & KEY_MOUSE_WARP)) {
+    if (mappedKey.rawKey & KEY_MOUSE_BUTTON) {
+        uint8_t button = mappedKey.rawKey & ~KEY_MOUSE_BUTTON;
+
+        if (key_toggled_on(keyState)) {
+            MouseWrapper.press_button(button);
+        } else if (key_toggled_off(keyState)) {
+            MouseWrapper.release_button(button);
+        }
+    } else if (!(mappedKey.rawKey & KEY_MOUSE_WARP)) {
         handle_mouse_key_event(mappedKey, keyState);
     } else if (key_toggled_on(keyState)) {
         if (mappedKey.rawKey & KEY_MOUSE_WARP && mappedKey.flags & IS_MOUSE_KEY) {

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -54,5 +54,11 @@ static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState)
 }
 
 MouseKeys_::MouseKeys_(void) {
+}
+
+void
+MouseKeys_::begin (void) {
     event_handler_hook_add (handleMouseKeys);
 }
+
+MouseKeys_ MouseKeys;

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -22,9 +22,9 @@ static void handle_mouse_key_event(Key mappedKey, uint8_t keyState) {
     }
 }
 
-static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState) {
+static Key handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState) {
     if (mappedKey.flags != (SYNTHETIC | IS_MOUSE_KEY))
-        return false;
+        return mappedKey;
 
     if (mappedKey.rawKey & KEY_MOUSE_BUTTON) {
         uint8_t button = mappedKey.rawKey & ~KEY_MOUSE_BUTTON;
@@ -46,7 +46,7 @@ static bool handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState)
         }
     }
 
-    return true;
+    return Key_NoKey;
 }
 
 MouseKeys_::MouseKeys_(void) {

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.h
@@ -3,9 +3,11 @@
 #include "KeyboardioFirmware.h"
 #include "MouseKeyDefs.h"
 
-class MouseKeys_ {
+class MouseKeys_ : public KeyboardioPlugin {
   public:
     MouseKeys_ (void);
+
+    virtual void begin(void) final;
 };
 
-static MouseKeys_ MouseKeys;
+extern MouseKeys_ MouseKeys;

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -5,14 +5,14 @@
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key
 #define KEY_MOUSE_BTN_M 0x02 // Synthetic key
-#define KEY_MOUSE_BTN_R 0x04 // Synthetic key
+#define KEY_MOUSE_BTN_R 0x03 // Synthetic key
 
 
 #define KEY_MOUSE_UP            B0000001
 #define KEY_MOUSE_DOWN          B0000010
 #define KEY_MOUSE_LEFT          B0000100
 #define KEY_MOUSE_RIGHT         B0001000
-#define KEY_MOUSE_CENTER        B0010000
+#define KEY_MOUSE_BUTTON        B0010000
 #define KEY_MOUSE_WARP          B0100000
 #define KEY_MOUSE_WARP_END      B1000000
 
@@ -36,6 +36,6 @@
 #define Key_mouseScrollDn
 #define Key_mouseScrollL
 #define Key_mouseScrollR
-#define Key_mouseBtnL    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_L }
-#define Key_mouseBtnM    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_M }
-#define Key_mouseBtnR    (Key){ KEY_FLAGS | SYNTHETIC, KEY_MOUSE_BTN_R }
+#define Key_mouseBtnL    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_L }
+#define Key_mouseBtnM    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_M }
+#define Key_mouseBtnR    (Key){ KEY_FLAGS | SYNTHETIC | IS_MOUSE_KEY, KEY_MOUSE_BUTTON | KEY_MOUSE_BTN_R }

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MOUSE_KEY     		   B00010000
+#define IS_MOUSE_KEY     		   B00000010
 
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key

--- a/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
+++ b/libraries/Keyboardio-MouseKeys/src/MouseKeyDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define IS_MOUSE_KEY     		   B00000010
+#define IS_MOUSE_KEY     		   B00010000
 
 // Synthetic, not internal
 #define KEY_MOUSE_BTN_L 0x01 // Synthetic key

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -1,4 +1,5 @@
 #include "KeyboardioFirmware.h"
+#include <stdarg.h>
 
 Keyboardio_::Keyboardio_(void) {
     memset(eventHandlers, 0, HOOK_MAX * sizeof(custom_handler_t));
@@ -7,7 +8,6 @@ Keyboardio_::Keyboardio_(void) {
 
 void
 Keyboardio_::setup(const byte keymap_count) {
-    event_handler_hook_add (handle_key_event_default);
     wdt_disable();
     delay(100);
     Keyboard.begin();
@@ -15,6 +15,8 @@ Keyboardio_::setup(const byte keymap_count) {
     LEDControl.setup();
 
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
+
+    event_handler_hook_add (handle_key_event_default);
 }
 
 custom_loop_t loopHooks[HOOK_MAX];
@@ -32,3 +34,15 @@ Keyboardio_::loop(void) {
     }
 }
 
+void
+Keyboardio_::use(KeyboardioPlugin *plugin, ...) {
+    va_list ap;
+    KeyboardioPlugin *p;
+
+    plugin->begin();
+    va_start(ap, plugin);
+    while ((p = va_arg(ap, KeyboardioPlugin*)) != NULL) {
+      p->begin();
+    };
+    va_end(ap);
+}

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -15,8 +15,6 @@ Keyboardio_::setup(const byte keymap_count) {
     LEDControl.setup();
 
     temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
-
-    event_handler_hook_add (handle_key_event_default);
 }
 
 custom_loop_t loopHooks[HOOK_MAX];

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -24,12 +24,18 @@ void
 Keyboardio_::loop(void) {
     KeyboardHardware.scan_matrix();
     LEDControl.update();
+
+    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
+      custom_loop_t hook = loopHooks[i];
+      (*hook)(false);
+    }
+
     Keyboard.sendReport();
     Keyboard.releaseAll();
 
     for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
       custom_loop_t hook = loopHooks[i];
-      (*hook)();
+      (*hook)(true);
     }
 }
 

--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -13,8 +13,9 @@ Keyboardio_::setup(const byte keymap_count) {
     Keyboard.begin();
     KeyboardHardware.setup();
     LEDControl.setup();
+    Layer.begin();
 
-    temporary_keymap = primary_keymap = Storage.load_primary_keymap(keymap_count);
+    Layer.defaultLayer (Storage.load_primary_keymap (keymap_count));
 }
 
 custom_loop_t loopHooks[HOOK_MAX];

--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -23,6 +23,7 @@ void setup();
 
 #include "KeyboardConfig.h"
 #include "key_events.h"
+#include "plugin.h"
 
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
@@ -41,6 +42,7 @@ class Keyboardio_ {
 
     void setup(const byte keymap_count);
     void loop(void);
+    void use(KeyboardioPlugin *plugin, ...);
 };
 
 static Keyboardio_ Keyboardio;

--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -24,11 +24,9 @@ void setup();
 #include "KeyboardConfig.h"
 #include "key_events.h"
 #include "plugin.h"
+#include "layers.h"
 
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
-
-extern uint8_t primary_keymap;
-extern uint8_t temporary_keymap;
 
 #ifndef VERSION
 #define VERSION "locally-built"

--- a/src/LED-BreatheEffect.cpp
+++ b/src/LED-BreatheEffect.cpp
@@ -1,14 +1,14 @@
 #include "LED-BreatheEffect.h"
 
-LEDBreatheEffect::LEDBreatheEffect (void) {
+LEDBreatheEffect_::LEDBreatheEffect_ (void) {
   state.brightness = 0;
   state.fadeAmount = 1;
-
-  LEDControl.mode_add (this);
 }
 
 void
-LEDBreatheEffect::update (void) {
+LEDBreatheEffect_::update (void) {
   cRGB color = breath_compute (&state);
   LEDControl.set_all_leds_to (color);
 }
+
+LEDBreatheEffect_ LEDBreatheEffect;

--- a/src/LED-BreatheEffect.h
+++ b/src/LED-BreatheEffect.h
@@ -3,12 +3,14 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDBreatheEffect : LEDMode {
+class LEDBreatheEffect_ : LEDMode {
  public:
-  LEDBreatheEffect (void);
+  LEDBreatheEffect_ (void);
 
   virtual void update (void) final;
 
  private:
   BreathState state;
 };
+
+extern LEDBreatheEffect_ LEDBreatheEffect;

--- a/src/LED-ChaseEffect.cpp
+++ b/src/LED-ChaseEffect.cpp
@@ -1,11 +1,10 @@
 #include "LED-ChaseEffect.h"
 
-LEDChaseEffect::LEDChaseEffect (void) {
-  LEDControl.mode_add (this);
+LEDChaseEffect_::LEDChaseEffect_ (void) {
 }
 
 void
-LEDChaseEffect::update (void) {
+LEDChaseEffect_::update (void) {
   if (current_chase_counter++ < chase_threshold) {
     return;
   }
@@ -20,3 +19,5 @@ LEDChaseEffect::update (void) {
   led_set_crgb_at(pos, {0, 0, 255});
   led_set_crgb_at(pos - (chase_sign * chase_pixels), {255, 0, 0});
 }
+
+LEDChaseEffect_ LEDChaseEffect;

--- a/src/LED-ChaseEffect.h
+++ b/src/LED-ChaseEffect.h
@@ -3,9 +3,9 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDChaseEffect : LEDMode {
+class LEDChaseEffect_ : LEDMode {
  public:
-  LEDChaseEffect (void);
+  LEDChaseEffect_ (void);
 
   virtual void update (void) final;
 
@@ -16,3 +16,5 @@ class LEDChaseEffect : LEDMode {
   uint8_t current_chase_counter = 0;
   static const uint8_t chase_threshold = 20;
 };
+
+extern LEDChaseEffect_ LEDChaseEffect;

--- a/src/LED-Numlock.cpp
+++ b/src/LED-Numlock.cpp
@@ -7,11 +7,15 @@ static uint8_t us;
 
 LEDNumlock::LEDNumlock (uint8_t numpadIdx) {
   numpadIndex = numpadIdx;
-  us = LEDControl.mode_add (this);
-  loop_hook_add (this->loopHook);
 
   breathState.brightness = 0;
   breathState.fadeAmount = 1;
+}
+
+void
+LEDNumlock::begin (void) {
+  us = LEDControl.mode_add (this);
+  loop_hook_add (this->loopHook);
 }
 
 void

--- a/src/LED-Numlock.cpp
+++ b/src/LED-Numlock.cpp
@@ -1,15 +1,16 @@
 #include "LED-Numlock.h"
 #include "LEDUtils.h"
+#include "layers.h"
 
 static uint8_t numpadIndex;
 static uint8_t storedLEDMode;
 static uint8_t us;
 
 LEDNumlock::LEDNumlock (uint8_t numpadIdx) {
-  numpadIndex = numpadIdx;
+    numpadIndex = numpadIdx;
 
-  breathState.brightness = 0;
-  breathState.fadeAmount = 1;
+    breathState.brightness = 0;
+    breathState.fadeAmount = 1;
 }
 
 void
@@ -20,35 +21,35 @@ LEDNumlock::begin (void) {
 
 void
 LEDNumlock::setup (void) {
-  if (temporary_keymap != numpadIndex) {
-    LEDControl.next_mode ();
-  }
+    if (!Layer.isOn (numpadIndex)) {
+        LEDControl.next_mode ();
+    }
 }
 
 void
 LEDNumlock::update (void) {
-  for (uint8_t i = 0; i < 44; i++) {
-    led_set_crgb_at(i, {0, 0, 0});
-  }
-  for (uint8_t i = 44; i < LED_COUNT; i++) {
-    led_set_crgb_at(i, {255, 0, 0});
-  }
+    for (uint8_t i = 0; i < 44; i++) {
+        led_set_crgb_at(i, {0, 0, 0});
+    }
+    for (uint8_t i = 44; i < LED_COUNT; i++) {
+        led_set_crgb_at(i, {255, 0, 0});
+    }
 
-  cRGB color = breath_compute (&breathState);
-  led_set_crgb_at (60, color);
+    cRGB color = breath_compute (&breathState);
+    led_set_crgb_at (60, color);
 }
 
 void
 LEDNumlock::loopHook (void) {
-  if (temporary_keymap == numpadIndex) {
-    if (storedLEDMode != us) {
-      storedLEDMode = LEDControl.get_mode ();
+    if (Layer.isOn (numpadIndex)) {
+        if (storedLEDMode != us) {
+            storedLEDMode = LEDControl.get_mode ();
+        }
+        LEDControl.set_mode (us);
     }
-    LEDControl.set_mode (us);
-  }
 
-  if (temporary_keymap != numpadIndex &&
-      LEDControl.get_mode () == us) {
-    LEDControl.set_mode (storedLEDMode);
-  }
+    if (!Layer.isOn (numpadIndex) &&
+            LEDControl.get_mode () == us) {
+        LEDControl.set_mode (storedLEDMode);
+    }
 }

--- a/src/LED-Numlock.cpp
+++ b/src/LED-Numlock.cpp
@@ -40,7 +40,10 @@ LEDNumlock::update (void) {
 }
 
 void
-LEDNumlock::loopHook (void) {
+LEDNumlock::loopHook (bool postClear) {
+    if (!postClear)
+        return;
+
     if (Layer.isOn (numpadIndex)) {
         if (storedLEDMode != us) {
             storedLEDMode = LEDControl.get_mode ();

--- a/src/LED-Numlock.h
+++ b/src/LED-Numlock.h
@@ -7,6 +7,8 @@ class LEDNumlock : LEDMode {
  public:
   LEDNumlock (uint8_t numpadIndex);
 
+  virtual void begin (void) final;
+
   virtual void update (void) final;
   virtual void setup (void) final;
 

--- a/src/LED-Numlock.h
+++ b/src/LED-Numlock.h
@@ -13,7 +13,7 @@ class LEDNumlock : LEDMode {
   virtual void setup (void) final;
 
  private:
-  static void loopHook (void);
+  static void loopHook (bool postClear);
 
   BreathState breathState;
 };

--- a/src/LED-Off.cpp
+++ b/src/LED-Off.cpp
@@ -1,0 +1,3 @@
+#include "LED-Off.h"
+
+LEDOff_ LEDOff;

--- a/src/LED-Off.h
+++ b/src/LED-Off.h
@@ -2,7 +2,9 @@
 
 #include "LEDControl.h"
 
-class LEDOff : LEDMode {
+class LEDOff_ : public LEDMode {
  public:
-  LEDOff (void) { LEDControl.mode_add (this); };
+  LEDOff_ (void) { };
 };
+
+extern LEDOff_ LEDOff;

--- a/src/LED-RainbowEffect.cpp
+++ b/src/LED-RainbowEffect.cpp
@@ -1,11 +1,10 @@
 #include "LED-RainbowEffect.h"
 
-LEDRainbowEffect::LEDRainbowEffect (void) {
-  LEDControl.mode_add (this);
+LEDRainbowEffect_::LEDRainbowEffect_ (void) {
 }
 
 void
-LEDRainbowEffect::update (void) {
+LEDRainbowEffect_::update (void) {
   if (rainbow_current_ticks++ < rainbow_ticks) {
     return;
   } else {
@@ -21,14 +20,15 @@ LEDRainbowEffect::update (void) {
   LEDControl.set_all_leds_to(rainbow);
 }
 
+LEDRainbowEffect_ LEDRainbowEffect;
+
 // ---------
 
-LEDRainbowWaveEffect::LEDRainbowWaveEffect (void) {
-  LEDControl.mode_add (this);
+LEDRainbowWaveEffect_::LEDRainbowWaveEffect_ (void) {
 }
 
 void
-LEDRainbowWaveEffect::update (void) {
+LEDRainbowWaveEffect_::update (void) {
   if (rainbow_current_ticks++ < rainbow_wave_ticks) {
     return;
   } else {
@@ -48,3 +48,5 @@ LEDRainbowWaveEffect::update (void) {
     rainbow_hue -= 255;
   }
 }
+
+LEDRainbowWaveEffect_ LEDRainbowWaveEffect;

--- a/src/LED-RainbowEffect.h
+++ b/src/LED-RainbowEffect.h
@@ -3,9 +3,9 @@
 #include "LEDControl.h"
 #include "LEDUtils.h"
 
-class LEDRainbowEffect : LEDMode {
+class LEDRainbowEffect_ : LEDMode {
  public:
-  LEDRainbowEffect (void);
+  LEDRainbowEffect_ (void);
 
   virtual void update (void) final;
 
@@ -21,9 +21,11 @@ class LEDRainbowEffect : LEDMode {
 
 };
 
-class LEDRainbowWaveEffect : LEDMode {
+extern LEDRainbowEffect_ LEDRainbowEffect;
+
+class LEDRainbowWaveEffect_ : LEDMode {
  public:
-  LEDRainbowWaveEffect (void);
+  LEDRainbowWaveEffect_ (void);
 
   virtual void update (void) final;
 
@@ -37,3 +39,5 @@ class LEDRainbowWaveEffect : LEDMode {
   static const byte rainbow_saturation = 255;
   static const byte rainbow_value = 50;
 };
+
+extern LEDRainbowWaveEffect_ LEDRainbowWaveEffect;

--- a/src/LEDControl.cpp
+++ b/src/LEDControl.cpp
@@ -5,6 +5,11 @@ LEDMode::activate (void) {
   LEDControl.activate (this);
 }
 
+void
+LEDMode::begin(void) {
+  LEDControl.mode_add(this);
+}
+
 LEDControl_::LEDControl_(void) {
   memset (modes, 0, LED_MAX_MODES * sizeof (modes[0]));
 }

--- a/src/LEDControl.h
+++ b/src/LEDControl.h
@@ -2,11 +2,13 @@
 
 #include <Arduino.h>
 #include "KeyboardConfig.h"
+#include "plugin.h"
 
 #define LED_MAX_MODES 24
 
-class LEDMode {
+class LEDMode : public KeyboardioPlugin {
  public:
+  virtual void begin (void);
   virtual void setup (void) {};
   virtual void init (void) {};
   virtual void update (void) {};

--- a/src/TestMode.cpp
+++ b/src/TestMode.cpp
@@ -109,9 +109,9 @@ void TestMode_::loop() {
 	TestMatrix();
 }
 
-bool handle_key_event_test(Key mappedKey, byte row, byte col, uint8_t keyState) {
+Key handle_key_event_test(Key mappedKey, byte row, byte col, uint8_t keyState) {
     Serial.write(row);
-    return false;
+    return mappedKey;
 }
 
 TestMode_ TestMode;

--- a/src/TestMode.cpp
+++ b/src/TestMode.cpp
@@ -2,8 +2,6 @@
 #include "TestMode.h"
 #include "LED-RainbowEffect.h"
 
-static LEDRainbowEffect testRainbowEffect;
-
 cRGB red;
 cRGB blue;
 
@@ -47,7 +45,7 @@ void TestMode_::TestLEDs(void) {
     delay(LED_TEST_DELAY);
     // rainbow for 10 seconds
     for(auto i=0; i<1000; i++ ) {
-        testRainbowEffect.update();
+        LEDRainbowEffect.update();
         led_sync();
     }
     // set all the keys to red

--- a/src/TestMode.h
+++ b/src/TestMode.h
@@ -16,4 +16,4 @@ class TestMode_ {
 
 extern TestMode_ TestMode;
 
-bool handle_key_event_test(Key mappedKey, byte row, byte col, uint8_t keyState);
+Key handle_key_event_test(Key mappedKey, byte row, byte col, uint8_t keyState);

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -5,7 +5,7 @@
 
 #define HOOK_MAX 64
 
-typedef bool (*custom_handler_t)(Key mappedKey, byte row, byte col, uint8_t keyState);
+typedef Key (*custom_handler_t)(Key mappedKey, byte row, byte col, uint8_t keyState);
 extern custom_handler_t eventHandlers[HOOK_MAX];
 
 void event_handler_hook_add (custom_handler_t hook);

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -11,7 +11,7 @@ extern custom_handler_t eventHandlers[HOOK_MAX];
 void event_handler_hook_add (custom_handler_t hook);
 void event_handler_hook_replace (custom_handler_t oldHook, custom_handler_t newHook);
 
-typedef void (*custom_loop_t)(void);
+typedef void (*custom_loop_t)(bool postClear);
 extern custom_loop_t loopHooks[HOOK_MAX];
 
 void loop_hook_add (custom_loop_t hook);

--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -58,6 +58,8 @@ typedef union {
 #define Key_NoKey (Key){ KEY_FLAGS,0 }
 #define Key_skip (Key){ KEY_FLAGS,0 }
 #define Key_Transparent (Key){ .raw = 0xffff }
+#define ___ Key_Transparent
+#define XXX Key_NoKey
 
 
 #define Key_powerDown (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_POWER_DOWN }

--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -32,8 +32,9 @@ typedef union {
 #define IS_SYSCTL                  B00000001
 #define IS_CONSUMER                B00000010
 #define SWITCH_TO_KEYMAP 		       B00000100
-#define SWITCH_TO_KEYMAP_MOMENTARY B00001000
-#define IS_INTERNAL                B00010000
+#define IS_INTERNAL                B00001000
+
+#define MOMENTARY_OFFSET 42
 
 // IS_INTERNAL key table:
 
@@ -50,12 +51,13 @@ typedef union {
 #define KEYMAP_7     7
 
 
-#define KEYMAP_PREVIOUS  253
-#define KEYMAP_NEXT      254
+#define KEYMAP_PREVIOUS  33
+#define KEYMAP_NEXT      34
 
 
 #define Key_NoKey (Key){ KEY_FLAGS,0 }
 #define Key_skip (Key){ KEY_FLAGS,0 }
+#define Key_Transparent (Key){ .raw = 0xffff }
 
 
 #define Key_powerDown (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_POWER_DOWN }
@@ -240,15 +242,15 @@ typedef union {
 #define Key_Keymap3 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_3 }
 #define Key_Keymap4 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_4 }
 #define Key_Keymap5 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_5 }
-#define Key_Keymap0_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_0 }
-#define Key_Keymap1_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_1 }
-#define Key_Keymap2_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_2 }
-#define Key_Keymap3_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_3 }
-#define Key_Keymap4_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_4 }
-#define Key_Keymap5_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_5 }
+#define Key_Keymap0_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_0 + MOMENTARY_OFFSET}
+#define Key_Keymap1_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_1 + MOMENTARY_OFFSET}
+#define Key_Keymap2_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_2 + MOMENTARY_OFFSET }
+#define Key_Keymap3_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_3 + MOMENTARY_OFFSET }
+#define Key_Keymap4_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_4 + MOMENTARY_OFFSET }
+#define Key_Keymap5_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_5 + MOMENTARY_OFFSET }
 
-#define Key_KeymapNext_Momentary (Key) {KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_NEXT }
-#define Key_KeymapPrevious_Momentary (Key) {KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP_MOMENTARY, KEYMAP_PREVIOUS }
+#define Key_KeymapNext_Momentary (Key) {KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_NEXT + MOMENTARY_OFFSET }
+#define Key_KeymapPrevious_Momentary (Key) {KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_PREVIOUS + MOMENTARY_OFFSET }
 
 
 

--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -19,7 +19,8 @@ typedef union {
 #define RALT_HELD         B00000100
 #define SHIFT_HELD        B00001000
 #define GUI_HELD          B00010000
-#define SYNTHETIC         B10000000
+#define SYNTHETIC         B01000000
+#define RESERVED          B10000000
 
 #define LCTRL(k)  ((Key) { k.flags | CTRL_HELD, k.rawKey })
 #define LALT(k)   ((Key) { k.flags | LALT_HELD, k.rawKey })
@@ -28,16 +29,15 @@ typedef union {
 #define LGUI(k)   ((Key) { k.flags | GUI_HELD, k.rawKey })
 
 // we assert that synthetic keys can never have keys held, so we reuse the _HELD bits
-#define IS_SYSCTL        B00000010
-#define IS_CONSUMER      B00000100
-#define IS_INTERNAL      B00001000
-#define SWITCH_TO_KEYMAP 		   B00100000
-#define SWITCH_TO_KEYMAP_MOMENTARY         B01000000
-
+#define IS_SYSCTL                  B00000001
+#define IS_CONSUMER                B00000010
+#define SWITCH_TO_KEYMAP 		       B00000100
+#define SWITCH_TO_KEYMAP_MOMENTARY B00001000
+#define IS_INTERNAL                B00010000
 
 // IS_INTERNAL key table:
 
-#define LED_TOGGLE  0x01 // Synthetic, internal
+#define LED_TOGGLE   B00000001 // Synthetic, internal
 
 
 #define KEYMAP_0     0
@@ -253,4 +253,4 @@ typedef union {
 
 
 
-#define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL, LED_TOGGLE }
+#define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE, 0 }

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -89,7 +89,8 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
     }
     for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
         custom_handler_t handler = eventHandlers[i];
-        if ((*handler)(mappedKey, row, col, keyState))
+        mappedKey = (*handler)(mappedKey, row, col, keyState);
+        if (mappedKey.raw == Key_NoKey.raw)
             return;
     }
     handle_key_event_default(mappedKey, row, col, keyState);

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -60,18 +60,7 @@ Key lookup_key(byte keymap, byte row, byte col) {
     return mappedKey;
 }
 
-void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
-    if (!(keyState & INJECTED)) {
-        mappedKey = lookup_key(temporary_keymap, row, col);
-    }
-    for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
-        custom_handler_t handler = eventHandlers[i];
-        if ((*handler)(mappedKey, row, col, keyState))
-            return;
-    }
-}
-
-bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState) {
+static bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState) {
     //for every newly pressed button, figure out what logical key it is and send a key down event
     // for every newly released button, figure out what logical key it is and send a key up event
 
@@ -130,4 +119,16 @@ void release_key(Key mappedKey) {
         Keyboard.release(Key_LGUI.rawKey);
     }
     Keyboard.release(mappedKey.rawKey);
+}
+
+void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
+    if (!(keyState & INJECTED)) {
+        mappedKey = lookup_key(temporary_keymap, row, col);
+    }
+    for (byte i = 0; eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
+        custom_handler_t handler = eventHandlers[i];
+        if ((*handler)(mappedKey, row, col, keyState))
+            return;
+    }
+    handle_key_event_default(mappedKey, row, col, keyState);
 }

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -48,6 +48,5 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState);
 // Internal use
 void press_key(Key mappedKey);
 void release_key(Key mappedKey);
-bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 Key lookup_key(byte keymap, byte row, byte col);

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -9,9 +9,6 @@
 #include "keymap_metadata.h"
 #include "hooks.h"
 
-//static const Key keymaps[KEYMAPS][ROWS][COLS];
-extern uint8_t primary_keymap;
-extern uint8_t temporary_keymap;
 extern const Key keymaps[][ROWS][COLS];
 
 // sending events to the computer
@@ -48,5 +45,3 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState);
 // Internal use
 void press_key(Key mappedKey);
 void release_key(Key mappedKey);
-
-Key lookup_key(byte keymap, byte row, byte col);

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -46,10 +46,8 @@ extern const Key keymaps[][ROWS][COLS];
 void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 // Internal use
-void handle_synthetic_key_event( Key mappedKey, uint8_t keyState);
 void press_key(Key mappedKey);
 void release_key(Key mappedKey);
-void handle_keymap_key_event(Key keymapEntry, uint8_t keyState);
 bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t keyState);
 
 Key lookup_key(byte keymap, byte row, byte col);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -33,13 +33,13 @@ static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
     }
 }
 
-static bool
+static Key
 layerEventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
     if (mappedKey.flags != (SYNTHETIC | SWITCH_TO_KEYMAP))
-        return false;
+        return mappedKey;
 
     handle_keymap_key_event(mappedKey, keyState);
-    return true;
+    return Key_NoKey;
 }
 
 Layer_::Layer_ (void) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -6,22 +6,24 @@ static uint32_t LayerState;
 
 static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
     if (keymapEntry.rawKey >= MOMENTARY_OFFSET) {
+        uint8_t target = keymapEntry.rawKey - MOMENTARY_OFFSET;
+
         if (key_toggled_on(keyState)) {
-            if ( keymapEntry.rawKey == KEYMAP_NEXT) {
+            if ( target == KEYMAP_NEXT) {
                 Layer.next();
-            } else if ( keymapEntry.rawKey == KEYMAP_PREVIOUS) {
+            } else if ( target == KEYMAP_PREVIOUS) {
                 Layer.previous();
             } else {
-                Layer.on(keymapEntry.rawKey - MOMENTARY_OFFSET);
+                Layer.on(target);
             }
         }
         if (key_toggled_off(keyState)) {
-            if ( keymapEntry.rawKey == KEYMAP_NEXT) {
+            if ( target == KEYMAP_NEXT) {
                 Layer.previous();
-            } else if ( keymapEntry.rawKey == KEYMAP_PREVIOUS) {
+            } else if ( target == KEYMAP_PREVIOUS) {
                 Layer.next();
             } else {
-                Layer.off(keymapEntry.rawKey - MOMENTARY_OFFSET);
+                Layer.off(target);
             }
         }
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -1,0 +1,113 @@
+#include "layers.h"
+#include "key_events.h"
+
+static uint8_t DefaultLayer;
+static uint32_t LayerState;
+
+static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
+    if (keymapEntry.rawKey >= MOMENTARY_OFFSET) {
+        if (key_toggled_on(keyState)) {
+            if ( keymapEntry.rawKey == KEYMAP_NEXT) {
+                Layer.next();
+            } else if ( keymapEntry.rawKey == KEYMAP_PREVIOUS) {
+                Layer.previous();
+            } else {
+                Layer.on(keymapEntry.rawKey - MOMENTARY_OFFSET);
+            }
+        }
+        if (key_toggled_off(keyState)) {
+            if ( keymapEntry.rawKey == KEYMAP_NEXT) {
+                Layer.previous();
+            } else if ( keymapEntry.rawKey == KEYMAP_PREVIOUS) {
+                Layer.next();
+            } else {
+                Layer.off(keymapEntry.rawKey - MOMENTARY_OFFSET);
+            }
+        }
+
+        // switch keymap and stay there
+    } else if (key_toggled_on(keyState)) {
+        Layer.on (keymapEntry.rawKey);
+    }
+}
+
+static bool
+layerEventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
+    if (mappedKey.flags != (SYNTHETIC | SWITCH_TO_KEYMAP))
+        return false;
+
+    handle_keymap_key_event(mappedKey, keyState);
+    return true;
+}
+
+Layer_::Layer_ (void) {
+}
+
+void Layer_::begin (void) {
+    defaultLayer (0);
+    event_handler_hook_add (layerEventHandler);
+}
+
+Key Layer_::lookup(byte row, byte col) {
+    Key mappedKey;
+    int8_t layer = 31;
+
+    mappedKey.raw = Key_Transparent.raw;
+
+    while (mappedKey.raw == Key_Transparent.raw &&
+           layer >= DefaultLayer) {
+        if (Layer.isOn (layer))
+            mappedKey.raw = pgm_read_word(&(keymaps[layer][row][col]));
+        layer--;
+    }
+
+    return mappedKey;
+}
+
+uint8_t Layer_::top (void) {
+    for (int8_t i = 31; i >= 0; i--) {
+        if (bitRead (LayerState, i))
+            return i;
+    }
+    return 0;
+}
+
+void Layer_::move (uint8_t layer) {
+    LayerState = 0;
+    on (layer);
+}
+
+void Layer_::on (uint8_t layer) {
+    bitSet (LayerState, layer);
+}
+
+void Layer_::off (uint8_t layer) {
+    bitClear (LayerState, layer);
+}
+
+boolean Layer_::isOn (uint8_t layer) {
+    return bitRead(LayerState, layer);
+}
+
+void Layer_::next (void) {
+    on (top () + 1);
+}
+
+void Layer_::previous (void) {
+    off (top ());
+}
+
+void Layer_::defaultLayer (uint8_t layer) {
+    move (layer);
+    DefaultLayer = layer;
+}
+
+uint8_t Layer_::defaultLayer (void) {
+    return DefaultLayer;
+}
+
+uint32_t Layer_::getLayerState (void) {
+    return LayerState;
+}
+
+Layer_ Layer;

--- a/src/layers.h
+++ b/src/layers.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+#include "key_defs.h"
+#include "plugin.h"
+
+class Layer_ : public KeyboardioPlugin {
+  public:
+    Layer_(void);
+
+    virtual void begin(void) final;
+
+    static Key lookup(byte row, byte col);
+    static void on(uint8_t layer);
+    static void off(uint8_t layer);
+    static void move(uint8_t layer);
+
+    static uint8_t top(void);
+    static void next(void);
+    static void previous(void);
+
+    static boolean isOn(uint8_t layer);
+
+    static void defaultLayer(uint8_t layer);
+    static uint8_t defaultLayer(void);
+
+    static uint32_t getLayerState(void);
+};
+
+extern Layer_ Layer;

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class KeyboardioPlugin {
+ public:
+  virtual void begin(void) = 0;
+};
+

--- a/tools/generate_keymaps.pl
+++ b/tools/generate_keymaps.pl
@@ -41,10 +41,15 @@ my %table = (
 	"'" => 'Key_Quote',
 	'`' => 'Key_Backtick',
 	'-' => 'Key_Minus',
-	'=' => 'Key_Equals');
+	'=' => 'Key_Equals',
+	'___' => '___',
+	'XXX' => 'XXX');
 
   my $x = shift;
   return $x if $x =~ /\(.*\)/;
+  return '___' if ($x =~ /_{2,}/);
+  return 'XXX' if ($x =~ /X{2,}/);
+
 	return 'Key_'.$x unless defined $table{$x};
 	return $table{$x};
 }


### PR DESCRIPTION
This is built upon #68 and #57, and changes how loops and event hooks work, again.

Loop hooks are called twice, once before sending & clearing the report, once after, to accommodate plugins that need to be able to choose when they run their loop hooks.

The event loop hook gained the ability to return a `Key`, to make replacing keycodes easier, and not necessarily need a re-inject.

The work is based on aforementioned PRs, because while I could rebase it on top of master, then the other two would need to be rebased on this. Sorry about that!