### PR TITLE
Do not crash if there are no LED effects

### DIFF
--- a/src/LEDControl.cpp
+++ b/src/LEDControl.cpp
@@ -6,6 +6,7 @@ LEDMode::activate (void) {
 }
 
 LEDControl_::LEDControl_(void) {
+  mode = previousMode = 0;
   memset (modes, 0, LED_MAX_MODES * sizeof (modes[0]));
 }
 
@@ -38,10 +39,12 @@ void
 LEDControl_::update (void) {
   if (previousMode != mode) {
     set_all_leds_to ({0, 0, 0});
-    (modes[mode]->init) ();
+    if (modes[mode])
+      (modes[mode]->init) ();
   }
 
-  (modes[mode]->update) ();
+  if (modes[mode])
+    (modes[mode]->update) ();
 
   led_sync ();
 
@@ -49,9 +52,9 @@ LEDControl_::update (void) {
 }
 
 void
-LEDControl_::set_mode (uint8_t mode) {
-  if (mode < LED_MAX_MODES)
-    this->mode = mode;
+LEDControl_::set_mode (uint8_t mode_) {
+  if (mode_ < LED_MAX_MODES)
+    mode = mode;
 }
 
 uint8_t


### PR DESCRIPTION
When trying to update the LEDs, do not unconditionally call `modes[mode]->init` and `modes[mode]->update`: we may have no effects installed. This change stops the firmware from crashing with an NPE if no LED effects are enabled.

Also sets mode and previousMode to zero in the constructor, so we start with a deterministic state.
