### PR TITLE
Add a sentinel attribute to Keyboardio.use()

### DIFF
--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -40,7 +40,7 @@ class Keyboardio_ {
 
     void setup(const byte keymap_count);
     void loop(void);
-    void use(KeyboardioPlugin *plugin, ...);
+    void use(KeyboardioPlugin *plugin, ...) __attribute__((sentinel));
 };
 
 static Keyboardio_ Keyboardio;


### PR DESCRIPTION
Makes it obvious when one forgets to close the arguments with a sentinel, by giving the compiler a hint.
