### PR TITLE
Allow env overwrite of ARDUINO_* vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
 DEVICE_PORT := `ls /dev/ttyACM*`
 DEVICE_PORT_BOOTLOADER := `ls /dev/ttyACM*`
-ARDUINO_PATH=/usr/local/arduino
-ARDUINO_LOCAL_LIB_PATH=$(HOME)/Arduino
+ARDUINO_PATH?=/usr/local/arduino
+ARDUINO_LOCAL_LIB_PATH?=$(HOME)/Arduino
 
 MD5 = md5sum
 


### PR DESCRIPTION
This allows to call make with `ARDUINO_PATH=/custom/install/loc make` to avoid
having to modify the Makefile when the arduino components are installed in non
standard installation paths.

I for example don't like to install binary downloads system-wide but just for my user and also have my own folder structure where I place the arduino libraries for keyboardio.
