### PR TITLE
Layers: Don't use hooks for the layer event handler

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -13,7 +13,6 @@ Keyboardio_::setup(const byte keymap_count) {
     Keyboard.begin();
     KeyboardHardware.setup();
     LEDControl.setup();
-    Layer.begin();
 
     Layer.defaultLayer (Storage.load_primary_keymap (keymap_count));
 }

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -93,5 +93,8 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
         if (mappedKey.raw == Key_NoKey.raw)
             return;
     }
+    mappedKey = Layer.eventHandler(mappedKey, row, col, keyState);
+    if (mappedKey.raw == Key_NoKey.raw)
+      return;
     handle_key_event_default(mappedKey, row, col, keyState);
 }

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -33,8 +33,8 @@ static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
     }
 }
 
-static Key
-layerEventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
+Key
+Layer_::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
     if (mappedKey.flags != (SYNTHETIC | SWITCH_TO_KEYMAP))
         return mappedKey;
 
@@ -43,11 +43,7 @@ layerEventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
 }
 
 Layer_::Layer_ (void) {
-}
-
-void Layer_::begin (void) {
     defaultLayer (0);
-    event_handler_hook_add (layerEventHandler);
 }
 
 Key Layer_::lookup(byte row, byte col) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -4,11 +4,9 @@
 #include "key_defs.h"
 #include "plugin.h"
 
-class Layer_ : public KeyboardioPlugin {
+class Layer_ {
   public:
     Layer_(void);
-
-    virtual void begin(void) final;
 
     static Key lookup(byte row, byte col);
     static void on(uint8_t layer);
@@ -25,6 +23,8 @@ class Layer_ : public KeyboardioPlugin {
     static uint8_t defaultLayer(void);
 
     static uint32_t getLayerState(void);
+
+    static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState);
 };
 
 extern Layer_ Layer;


### PR DESCRIPTION
The layer handling is a core functionality, it should be active at all times, and should be at the very end, before the default event handler. Otherwise there may be ordering issues, when a plugin wants to return layer keys from its own event handler.

This also saves us a couple of bytes of both code and data, as an additional bonus!