### PR TITLE
Prevent optimising out the hook functions

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -14,6 +14,9 @@ Keyboardio_::setup(const byte keymap_count) {
     KeyboardHardware.setup();
     LEDControl.setup();
 
+    event_handler_hook_add (NULL);
+    loop_hook_add (NULL);
+
     Layer.defaultLayer (Storage.load_primary_keymap (keymap_count));
 }
 


### PR DESCRIPTION
With the Layer code not using the hooks anymore, the Arduino builder will tell the linker to remove any unreferenced code. As we are using dot_a_linkage, that means that the hook functions will be removed due to being unreferenced before plugins had a chance to reference them.

Add a dummy call in `Keyboardio_::setup()` to prevent this case.
