### PR TITLE
Keyboardio: Change from static to extern

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -53,3 +53,5 @@ Keyboardio_::use(KeyboardioPlugin *plugin, ...) {
     };
     va_end(ap);
 }
+
+Keyboardio_ Keyboardio;

--- a/src/KeyboardioFirmware.h
+++ b/src/KeyboardioFirmware.h
@@ -43,4 +43,4 @@ class Keyboardio_ {
     void use(KeyboardioPlugin *plugin, ...) __attribute__((sentinel));
 };
 
-static Keyboardio_ Keyboardio;
+extern Keyboardio_ Keyboardio;


### PR DESCRIPTION
We want the `Keyboardio` object to be a singleton. If it is static, then each library that gets compiled separately, and uses it in one way or the other, will have a copy of it.

Making it extern, we'll only have one copy, as it should be.

I don't think there were any bugs caused by it being static, but it was certainly a tiny bit of wasted code and memory.
