### PR TITLE
key_defs: Add some operators

### DIFF
--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -2,13 +2,26 @@
 
 
 #include "HIDTables.h"
-typedef union {
+typedef union Key_ {
 
     struct {
         uint8_t flags;
         uint8_t rawKey;
     };
     uint16_t raw;
+
+    inline bool operator==(uint16_t rhs) { return this->raw == rhs; };
+    inline bool operator==(const Key_ rhs) { return this->raw == rhs.raw; };
+    inline Key_& operator=(uint16_t raw) { this->raw = raw; return *this; };
+    inline bool operator!=(const Key_& rhs) { return !(*this == rhs); };
+    inline bool operator>=(uint16_t raw) { return this->raw >= raw; };
+    inline bool operator<=(uint16_t raw) { return this->raw <= raw; };
+    inline bool operator>(uint16_t raw) { return this->raw > raw; };
+    inline bool operator<(uint16_t raw) { return this->raw < raw; };
+    inline bool operator>=(const Key_& other) { return this->raw >= other.raw; };
+    inline bool operator<=(const Key_& other) { return this->raw <= other.raw; };
+    inline bool operator>(const Key_& other) { return this->raw > other.raw; };
+    inline bool operator<(const Key_& other) { return this->raw < other.raw; };
 } Key;
 
 


### PR DESCRIPTION
Makes some code not only easier to follow (by not having to use `.raw` all the time), but for some odd reason, smaller too, in many cases.

I'm not 100% sure about this yet. First, it looks a bit ugly. Second, the savings aren't THAT big (although 20+ bytes of code is pretty big, for such little change), and I find it odd that the code becomes smaller. I would have expected it to be either the same, or bigger.

Some quick tests show that things still work as they did before, but... I'll have a look at the assembly too, to better understand why things get smaller. Submitting it meanwhile, to have your opinion as well.

I won't spend much time on it if you think this is unnecessary.