### PR TITLE
Rename Key.rawKey to Key.keyCode

### DIFF
--- a/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
+++ b/libraries/Keyboardio-Macros/src/Keyboardio-Macros.cpp
@@ -25,13 +25,13 @@ void Macros_::play(const macro_t *macro_p) {
         }
         case MACRO_ACTION_STEP_KEYDOWN:
             key.flags = pgm_read_byte(macro_p++);
-            key.rawKey = pgm_read_byte(macro_p++);
+            key.keyCode = pgm_read_byte(macro_p++);
             handle_key_event(key, 255, 255, IS_PRESSED | INJECTED);
             Keyboard.sendReport();
             break;
         case MACRO_ACTION_STEP_KEYUP:
             key.flags = pgm_read_byte(macro_p++);
-            key.rawKey = pgm_read_byte(macro_p++);
+            key.keyCode = pgm_read_byte(macro_p++);
             handle_key_event(key, 255, 255, WAS_PRESSED | INJECTED);
             Keyboard.sendReport();
             break;
@@ -51,7 +51,7 @@ static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState)
     if (!key_toggled_on(keyState))
       return Key_NoKey;
 
-    const macro_t *m = macroAction(mappedKey.rawKey, keyState);
+    const macro_t *m = macroAction(mappedKey.keyCode, keyState);
 
     Macros.play(m);
     return Key_NoKey;

--- a/libraries/Keyboardio-Macros/src/MacroSteps.h
+++ b/libraries/Keyboardio-Macros/src/MacroSteps.h
@@ -17,9 +17,9 @@ typedef uint8_t macro_t;
 
 #define I(n)  MACRO_ACTION_STEP_INTERVAL, n
 #define W(n)  MACRO_ACTION_STEP_WAIT, n
-#define Dr(k) MACRO_ACTION_STEP_KEYDOWN, (k).flags, (k).rawKey
+#define Dr(k) MACRO_ACTION_STEP_KEYDOWN, (k).flags, (k).keyCode
 #define D(k)  Dr(Key_ ## k)
-#define Ur(k) MACRO_ACTION_STEP_KEYUP, (k).flags, (k).rawKey
+#define Ur(k) MACRO_ACTION_STEP_KEYUP, (k).flags, (k).keyCode
 #define U(k)  Ur(Key_ ## k)
 #define Tr(k) Dr(k), Ur(k)
 #define T(k)  D(k), U(k)

--- a/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
+++ b/libraries/Keyboardio-MouseKeys/src/Keyboardio-MouseKeys.cpp
@@ -8,16 +8,16 @@ static void handle_mouse_key_event(Key mappedKey, uint8_t keyState) {
     if (!key_is_pressed(keyState))
         return;
 
-    if (mappedKey.rawKey & KEY_MOUSE_UP) {
+    if (mappedKey.keyCode & KEY_MOUSE_UP) {
         MouseWrapper.move(0,-1);
     }
-    if (mappedKey.rawKey & KEY_MOUSE_DOWN) {
+    if (mappedKey.keyCode & KEY_MOUSE_DOWN) {
         MouseWrapper.move(0,1);
     }
-    if (mappedKey.rawKey & KEY_MOUSE_LEFT) {
+    if (mappedKey.keyCode & KEY_MOUSE_LEFT) {
         MouseWrapper.move(-1,0);
     }
-    if (mappedKey.rawKey & KEY_MOUSE_RIGHT) {
+    if (mappedKey.keyCode & KEY_MOUSE_RIGHT) {
         MouseWrapper.move(1,0);
     }
 }
@@ -26,23 +26,23 @@ static Key handleMouseKeys(Key mappedKey, byte row, byte col, uint8_t keyState) 
     if (mappedKey.flags != (SYNTHETIC | IS_MOUSE_KEY))
         return mappedKey;
 
-    if (mappedKey.rawKey & KEY_MOUSE_BUTTON) {
-        uint8_t button = mappedKey.rawKey & ~KEY_MOUSE_BUTTON;
+    if (mappedKey.keyCode & KEY_MOUSE_BUTTON) {
+        uint8_t button = mappedKey.keyCode & ~KEY_MOUSE_BUTTON;
 
         if (key_toggled_on(keyState)) {
             MouseWrapper.press_button(button);
         } else if (key_toggled_off(keyState)) {
             MouseWrapper.release_button(button);
         }
-    } else if (!(mappedKey.rawKey & KEY_MOUSE_WARP)) {
+    } else if (!(mappedKey.keyCode & KEY_MOUSE_WARP)) {
         handle_mouse_key_event(mappedKey, keyState);
     } else if (key_toggled_on(keyState)) {
-        if (mappedKey.rawKey & KEY_MOUSE_WARP && mappedKey.flags & IS_MOUSE_KEY) {
+        if (mappedKey.keyCode & KEY_MOUSE_WARP && mappedKey.flags & IS_MOUSE_KEY) {
             // we don't pass in the left and up values because those are the
             // default, "no-op" conditionals
-            MouseWrapper.warp( ((mappedKey.rawKey & KEY_MOUSE_WARP_END) ? WARP_END : 0x00) |
-                               ((mappedKey.rawKey & KEY_MOUSE_DOWN) ? WARP_DOWN : 0x00) |
-                               ((mappedKey.rawKey & KEY_MOUSE_RIGHT) ? WARP_RIGHT : 0x00) );
+            MouseWrapper.warp( ((mappedKey.keyCode & KEY_MOUSE_WARP_END) ? WARP_END : 0x00) |
+                               ((mappedKey.keyCode & KEY_MOUSE_DOWN) ? WARP_DOWN : 0x00) |
+                               ((mappedKey.keyCode & KEY_MOUSE_RIGHT) ? WARP_RIGHT : 0x00) );
         }
     }
 

--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -6,7 +6,7 @@ typedef union {
 
     struct {
         uint8_t flags;
-        uint8_t rawKey;
+        uint8_t keyCode;
     };
     uint16_t raw;
 } Key;
@@ -22,11 +22,11 @@ typedef union {
 #define SYNTHETIC         B01000000
 #define RESERVED          B10000000
 
-#define LCTRL(k)  ((Key) { k.flags | CTRL_HELD, k.rawKey })
-#define LALT(k)   ((Key) { k.flags | LALT_HELD, k.rawKey })
-#define RALT(k)   ((Key) { k.flags | RALT_HELD, k.rawKey })
-#define LSHIFT(k) ((Key) { k.flags | SHIFT_HELD, k.rawKey })
-#define LGUI(k)   ((Key) { k.flags | GUI_HELD, k.rawKey })
+#define LCTRL(k)  ((Key) { k.flags | CTRL_HELD, k.keyCode })
+#define LALT(k)   ((Key) { k.flags | LALT_HELD, k.keyCode })
+#define RALT(k)   ((Key) { k.flags | RALT_HELD, k.keyCode })
+#define LSHIFT(k) ((Key) { k.flags | SHIFT_HELD, k.keyCode })
+#define LGUI(k)   ((Key) { k.flags | GUI_HELD, k.keyCode })
 
 // we assert that synthetic keys can never have keys held, so we reuse the _HELD bits
 #define IS_SYSCTL                  B00000001

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -18,9 +18,9 @@ static bool handle_synthetic_key_event(Key mappedKey, uint8_t keyState) {
             return false;
         }
     } else if (mappedKey.flags & IS_CONSUMER) {
-        ConsumerControl.press(mappedKey.rawKey);
+        ConsumerControl.press(mappedKey.keyCode);
     } else if (mappedKey.flags & IS_SYSCTL) {
-        SystemControl.press(mappedKey.rawKey);
+        SystemControl.press(mappedKey.keyCode);
     } else if (mappedKey.flags & SWITCH_TO_KEYMAP) {
         // Should not happen, handled elsewhere.
     }
@@ -46,41 +46,41 @@ static bool handle_key_event_default(Key mappedKey, byte row, byte col, uint8_t 
 
 void press_key(Key mappedKey) {
     if (mappedKey.flags & SHIFT_HELD) {
-        Keyboard.press(Key_LShift.rawKey);
+        Keyboard.press(Key_LShift.keyCode);
     }
     if (mappedKey.flags & CTRL_HELD) {
-        Keyboard.press(Key_LCtrl.rawKey);
+        Keyboard.press(Key_LCtrl.keyCode);
     }
     if (mappedKey.flags & LALT_HELD) {
-        Keyboard.press(Key_LAlt.rawKey);
+        Keyboard.press(Key_LAlt.keyCode);
     }
     if (mappedKey.flags & RALT_HELD) {
-        Keyboard.press(Key_RAlt.rawKey);
+        Keyboard.press(Key_RAlt.keyCode);
     }
     if (mappedKey.flags & GUI_HELD) {
-        Keyboard.press(Key_LGUI.rawKey);
+        Keyboard.press(Key_LGUI.keyCode);
     }
-    Keyboard.press(mappedKey.rawKey);
+    Keyboard.press(mappedKey.keyCode);
 }
 
 
 void release_key(Key mappedKey) {
     if (mappedKey.flags & SHIFT_HELD) {
-        Keyboard.release(Key_LShift.rawKey);
+        Keyboard.release(Key_LShift.keyCode);
     }
     if (mappedKey.flags & CTRL_HELD) {
-        Keyboard.release(Key_LCtrl.rawKey);
+        Keyboard.release(Key_LCtrl.keyCode);
     }
     if (mappedKey.flags & LALT_HELD) {
-        Keyboard.release(Key_LAlt.rawKey);
+        Keyboard.release(Key_LAlt.keyCode);
     }
     if (mappedKey.flags & RALT_HELD) {
-        Keyboard.release(Key_RAlt.rawKey);
+        Keyboard.release(Key_RAlt.keyCode);
     }
     if (mappedKey.flags & GUI_HELD) {
-        Keyboard.release(Key_LGUI.rawKey);
+        Keyboard.release(Key_LGUI.keyCode);
     }
-    Keyboard.release(mappedKey.rawKey);
+    Keyboard.release(mappedKey.keyCode);
 }
 
 void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -5,8 +5,8 @@ static uint8_t DefaultLayer;
 static uint32_t LayerState;
 
 static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
-    if (keymapEntry.rawKey >= MOMENTARY_OFFSET) {
-        uint8_t target = keymapEntry.rawKey - MOMENTARY_OFFSET;
+    if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {
+        uint8_t target = keymapEntry.keyCode - MOMENTARY_OFFSET;
 
         if (key_toggled_on(keyState)) {
             if ( target == KEYMAP_NEXT) {
@@ -29,7 +29,7 @@ static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
 
         // switch keymap and stay there
     } else if (key_toggled_on(keyState)) {
-        Layer.on (keymapEntry.rawKey);
+        Layer.on (keymapEntry.keyCode);
     }
 }
 


### PR DESCRIPTION
Because we have `raw`, `rawKey` was confusing. Rename it to `keyCode` instead, which better conveys what the byte is for.
