### PR TITLE
Sync the LEDs at the end of the loop

### DIFF
--- a/src/KeyboardioFirmware.cpp
+++ b/src/KeyboardioFirmware.cpp
@@ -39,6 +39,8 @@ Keyboardio_::loop(void) {
       custom_loop_t hook = loopHooks[i];
       (*hook)(true);
     }
+
+    led_sync ();
 }
 
 void

--- a/src/LEDControl.cpp
+++ b/src/LEDControl.cpp
@@ -51,8 +51,6 @@ LEDControl_::update (void) {
   if (modes[mode])
     (modes[mode]->update) ();
 
-  led_sync ();
-
   previousMode = mode;
 }
 


### PR DESCRIPTION
Instead of syncing right after updating, sync at the end of the loop. This allows hooks (both loop and event handler hooks) to override LED colors, without cooperation from the active LED effect, and without flickering.
