### PR TITLE
Support an Arch-style Arduino installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,15 @@ SKETCH=KeyboardioFirmware.ino
 BOOTLOADER_PATH = $(ARDUINO_LOCAL_LIB_PATH)/hardware/keyboardio/avr/bootloaders/caterina/Caterina.hex
 VERBOSE= #-verbose
 
+ARDUINO_TOOLS_PARAM = -tools $(ARDUINO_TOOLS_PATH)
+ifeq ($(ARDUINO_TOOLS_PATH),)
+	ARDUINO_TOOLS_PARAM =
+endif
+
+ifdef AVR_GCC_PREFIX
+	ARDUINO_AVR_GCC_PREFIX_PREF = -prefs "runtime.tools.avr-gcc.path=$(AVR_GCC_PREFIX)"
+endif
+
 #
 #
 # Build
@@ -96,7 +105,7 @@ compile: dirs
 	$(ARDUINO_BUILDER_PATH) \
 		-hardware $(ARDUINO_PATH)/hardware \
 		-hardware $(ARDUINO_LOCAL_LIB_PATH)/hardware \
-		-tools $(ARDUINO_TOOLS_PATH) \
+		$(ARDUINO_TOOLS_PARAM) \
 		-tools $(ARDUINO_PATH)/tools-builder  \
 		-fqbn $(FQBN) \
 		-libraries $(ARDUINO_LOCAL_LIB_PATH) \
@@ -105,6 +114,7 @@ compile: dirs
 		$(VERBOSE) \
 		-build-path $(BUILD_PATH) \
 		-ide-version $(ARDUINO_IDE_VERSION) \
+		$(ARDUINO_AVR_GCC_PREFIX_PREF) \
 		examples/KeyboardioFirmware/$(SKETCH)
 	@cp $(BUILD_PATH)/$(SKETCH).hex $(HEX_FILE_PATH)
 	@cp $(BUILD_PATH)/$(SKETCH).elf $(ELF_FILE_PATH)


### PR DESCRIPTION
Arch puts the Arduino tools into /usr/bin, hardware bits under `/usr/share/arduino`, and so on. To make ends meet, and support both the traditional install, and Arch, introduce a bit of magic:

- If `ARDUINO_TOOLS_PATH` is empty, then we should not add the `-tools` param that refers to it. On arch, this is not needed, and there is no reasonable alternative, that would also make sense. So in this case, it should not be added at all. Setting the variable to an empty string accomplishes that goal nicely.

- If an `AVR_GCC_PREFIX` variable is set, use that as the value for `runtime.tools.avr-gcc.path`, otherwise `arduino-builder` will try to find the avr-* tools somewhere under the Arduino prefix, which on Arch, is not the case.

With this change, along with keyboardio/KeyboardioHID#3, and adding an `archlinux-arduino`=>`arduino` symlink somewhere, it becomes possible to complie KeyboardioFirmware on Arch, using the packaged Arduino, with the following commandline:

```
make ARDUINO_BUILDER_PATH=/usr/bin/arduino-builder \
     ARDUINO_PATH=/usr/share/arduino \
     ARDUINO_LOCAL_LIB_PATH=../arduino-local \
     AVR_GCC_PREFIX=/usr \
     ARDUINO_TOOLS_PATH= \
     AVR_SIZE_PATH=avr-size
```

Not the nicest, by far, but possible.
