### PR TITLE
Add a new tool to help build the firmware

### DIFF
--- a/.keyboardio-builder.conf
+++ b/.keyboardio-builder.conf
@@ -1,11 +1,11 @@
 # -*- mode: sh -*-
 
 generate_keymaps () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
-    rm -f generated/keymaps.h
-    (cd layouts && ( find . -type f | sort | xargs -n 1 -I % sh -c 'perl ../../../tools/generate_keymaps.pl < % >> ../generated/keymaps.h' ))
+    rm -f examples/KeyboardioFirmware/generated/keymaps.h
+    (cd examples/KeyboardioFirmware/layouts && \
+            ( find . -type f | sort | xargs -n 1 -I % sh -c 'perl ../../../tools/generate_keymaps.pl < % >> ../generated/keymaps.h' ))
 }
 
 EXTRA_BUILDER_ARGS="-libraries ${SOURCEDIR}/libraries"

--- a/.keyboardio-builder.conf
+++ b/.keyboardio-builder.conf
@@ -8,6 +8,5 @@ generate_keymaps () {
             ( find . -type f | sort | xargs -n 1 -I % sh -c 'perl ../../../tools/generate_keymaps.pl < % >> ../generated/keymaps.h' ))
 }
 
-EXTRA_BUILDER_ARGS="-libraries ${SOURCEDIR}/libraries"
 DEFAULT_SKETCH=KeyboardioFirmware
 compile_HOOKS="generate_keymaps"

--- a/.keyboardio-builder.conf
+++ b/.keyboardio-builder.conf
@@ -1,0 +1,13 @@
+# -*- mode: sh -*-
+
+generate_keymaps () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    rm -f generated/keymaps.h
+    (cd layouts && ( find . -type f | sort | xargs -n 1 -I % sh -c 'perl ../../../tools/generate_keymaps.pl < % >> ../generated/keymaps.h' ))
+}
+
+EXTRA_BUILDER_ARGS="-libraries ${SOURCEDIR}/libraries"
+DEFAULT_SKETCH=KeyboardioFirmware
+compile_HOOKS="generate_keymaps"

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,10 @@
 # default action for `make` is `build`
-build: compile size
+build:
 
 astyle:
 		find . -type f -name \*.cpp |xargs -n 1 astyle --style=google
 		find . -type f -name \*.ino |xargs -n 1 astyle --style=google
 		find . -type f -name \*.h |xargs -n 1 astyle --style=google
 
-generate-keymaps:
-	tools/keyboardio-builder generate-keymaps
-
-compile:
-	tools/keyboardio-builder compile
-
-size: compile
-	tools/keyboardio-builder report-size
-
-size-map: compile
-	tools/keyboardio-builder size-map
-
-decompile: compile
-	tools/keyboardio-builder decompile
-
-hex-with-bootloader: compile
-	tools/keyboardio-builder hex-with-bootloader
-
-reset-device:
-	tools/keyboardio-builder reset-device
-
-flash: compile reset-device
-	tools/keyboardio-builder flash
-
-program:
-	tools/keyboardio-builder program
+%:
+	@tools/keyboardio-builder $@

--- a/Makefile
+++ b/Makefile
@@ -1,91 +1,3 @@
-
-# Shamelessly stolen from git's Makefile
-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-
-
-DEVICE_PORT := `ls /dev/ttyACM*`
-DEVICE_PORT_BOOTLOADER := `ls /dev/ttyACM*`
-ARDUINO_PATH?=/usr/local/arduino
-ARDUINO_LOCAL_LIB_PATH?=$(HOME)/Arduino
-
-MD5 = md5sum
-
-RESET_BOARD=stty -F $(DEVICE_PORT) 1200 hupcl
-
-ifeq ($(uname_S),Darwin)
-
-# Port locations
-
-DEVICE_PORT :=  `ls /dev/cu.usbmodemHID?? /dev/cu.usbmodem14*`
-DEVICE_PORT_BOOTLOADER := `ls /dev/cu.usbmodem14*`
-
-# Tools
-
-ARDUINO_PATH=/Applications/Arduino.app/Contents/Java/
-ARDUINO_LOCAL_LIB_PATH=$(HOME)/Documents/Arduino
-
-MD5 = md5
-
-RESET_BOARD=stty -f $(DEVICE_PORT) 1200
-
-endif
-
-
-
-ARDUINO_TOOLS_PATH=$(ARDUINO_PATH)/hardware/tools
-ARDUINO_BUILDER_PATH=$(ARDUINO_PATH)/arduino-builder
-AVRDUDE_PATH=$(ARDUINO_TOOLS_PATH)/avr/bin/avrdude
-AVRDUDE_CONF_PATH=$(ARDUINO_TOOLS_PATH)/avr/etc/avrdude.conf
-AVR_SIZE_PATH=$(ARDUINO_TOOLS_PATH)/avr/bin/avr-size
-AVR_NM_PATH=$(ARDUINO_TOOLS_PATH)/avr/bin/avr-nm
-AVR_OBJDUMP_PATH=$(ARDUINO_TOOLS_PATH)/avr/bin/avr-objdump
-
-
-
-#
-#
-# Device and sketch info
-#
-#
-
-BOARD    = model01
-MCU 		= atmega32u4
-FQBN=keyboardio:avr:model01
-SKETCH=KeyboardioFirmware.ino
-BOOTLOADER_PATH = $(ARDUINO_LOCAL_LIB_PATH)/hardware/keyboardio/avr/bootloaders/caterina/Caterina.hex
-VERBOSE= #-verbose
-
-ARDUINO_TOOLS_PARAM = -tools $(ARDUINO_TOOLS_PATH)
-ifeq ($(ARDUINO_TOOLS_PATH),)
-	ARDUINO_TOOLS_PARAM =
-endif
-
-ifdef AVR_GCC_PREFIX
-	ARDUINO_AVR_GCC_PREFIX_PREF = -prefs "runtime.tools.avr-gcc.path=$(AVR_GCC_PREFIX)"
-endif
-
-#
-#
-# Build
-#
-#
-
-BUILD_PATH := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'build')
-OUTPUT_PATH=./output
-ARDUINO_IDE_VERSION=100607
-
-#
-#
-# Output 
-#
-#
-
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always)
-OUTPUT_FILE_PREFIX=$(SKETCH)-$(GIT_VERSION)
-HEX_FILE_PATH=$(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).hex
-ELF_FILE_PATH=$(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).elf
-HEX_FILE_WITH_BOOTLOADER_PATH=$(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX)-with-bootloader.hex
-
 # default action for `make` is `build`
 build: compile size
 
@@ -95,71 +7,28 @@ astyle:
 		find . -type f -name \*.h |xargs -n 1 astyle --style=google
 
 generate-keymaps:
-	-rm examples/KeyboardioFirmware/generated/keymaps.h
-	cd examples/KeyboardioFirmware/layouts && ( find . -type f | sort | xargs -n 1 -I % sh -c 'perl ../../../tools/generate_keymaps.pl < % >> ../generated/keymaps.h' )
+	tools/keyboardio-builder generate-keymaps
 
-dirs:
-	mkdir -p $(OUTPUT_PATH)
-
-compile: dirs
-	$(ARDUINO_BUILDER_PATH) \
-		-hardware $(ARDUINO_PATH)/hardware \
-		-hardware $(ARDUINO_LOCAL_LIB_PATH)/hardware \
-		$(ARDUINO_TOOLS_PARAM) \
-		-tools $(ARDUINO_PATH)/tools-builder  \
-		-fqbn $(FQBN) \
-		-libraries $(ARDUINO_LOCAL_LIB_PATH) \
-		-libraries . \
-		$(VERBOSE) \
-		-build-path $(BUILD_PATH) \
-		-ide-version $(ARDUINO_IDE_VERSION) \
-		$(ARDUINO_AVR_GCC_PREFIX_PREF) \
-		examples/KeyboardioFirmware/$(SKETCH)
-	@cp $(BUILD_PATH)/$(SKETCH).hex $(HEX_FILE_PATH)
-	@cp $(BUILD_PATH)/$(SKETCH).elf $(ELF_FILE_PATH)
-	@echo "Firmware is available at $(HEX_FILE_PATH)"
-	@echo "Have fun!\n"
+compile:
+	tools/keyboardio-builder compile
 
 size: compile
-	$(AVR_SIZE_PATH) -C --mcu=$(MCU) $(ELF_FILE_PATH)
+	tools/keyboardio-builder report-size
 
 size-map: compile
-	$(AVR_NM_PATH) --size-sort -C -r $(ELF_FILE_PATH)
+	tools/keyboardio-builder size-map
 
 decompile: compile
-	$(AVR_OBJDUMP_PATH) -d $(ELF_FILE_PATH)
+	tools/keyboardio-builder decompile
 
 hex-with-bootloader: compile
-	@cat $(HEX_FILE_PATH) | awk '/^:00000001FF/ == 0' > $(HEX_FILE_WITH_BOOTLOADER_PATH)
-	@echo "Using $(BOOTLOADER_PATH)"
-	@$(MD5) $(BOOTLOADER_PATH)
-	@cat $(BOOTLOADER_PATH) >> $(HEX_FILE_WITH_BOOTLOADER_PATH)
-	@echo "Combined firmware and bootloader are now at $(HEX_FILE_WITH_BOOTLOADER_PATH)"
-	@echo "Make sure you have the bootloader version you expect."
-	@echo "\n\nAnd TEST THIS ON REAL HARDWARE BEFORE YOU GIVE IT TO ANYONE\n\n"
+	tools/keyboardio-builder hex-with-bootloader
 
-reset-device: 
-	$(RESET_BOARD)
+reset-device:
+	tools/keyboardio-builder reset-device
 
 flash: compile reset-device
-	sleep 3
-	$(AVRDUDE_PATH) \
-		-C$(AVRDUDE_CONF_PATH) \
-		-v \
-		-p$(MCU) \
-		-cavr109 \
-		-P$(DEVICE_PORT_BOOTLOADER) \
-		-b57600 \
-		-D \
-		-Uflash:w:$(HEX_FILE_PATH):i 
+	tools/keyboardio-builder flash
 
 program:
-	$(AVRDUDE_PATH) \
-		-C$(AVRDUDE_CONF_PATH) \
-		-v \
-		-p$(MCU) \
-		-cusbtiny \
-		-D \
-		-B 1 \
-		-Uflash:w:$(HEX_FILE_PATH):i 
-
+	tools/keyboardio-builder program

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -55,7 +55,7 @@ find_sketch () {
 flash () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
@@ -70,7 +70,7 @@ flash () {
 program () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
@@ -88,7 +88,7 @@ program () {
 hex_with_bootloader () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
@@ -176,7 +176,7 @@ build_all () {
 report_size () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
@@ -188,7 +188,7 @@ report_size () {
 size_map () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
@@ -198,7 +198,7 @@ size_map () {
 decompile () {
     . ${ROOT}/tools/settings.sh
 
-    if [ ! -e "{HEX_FILE_PATH}" ]; then
+    if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -114,6 +114,10 @@ compile () {
 
     ${compile_HOOKS}
 
+    if [ -d "${ARDUINO_LOCAL_LIB_PATH}/libraries" ]; then
+        local_LIBS="-libraries \"${ARDUINO_LOCAL_LIB_PATH}/libraries\""
+    fi
+
     ${ARDUINO_BUILDER} \
         -compile \
 		    -hardware "${ARDUINO_PATH}/hardware" \
@@ -121,7 +125,7 @@ compile () {
 		    ${ARDUINO_TOOLS_PARAM} \
 		    -tools "${ARDUINO_PATH}/tools-builder" \
 		    -fqbn "${FQBN}" \
-		    -libraries "${ARDUINO_LOCAL_LIB_PATH}/libraries" \
+        ${local_LIBS} \
 		    -libraries "${BOARD_HARDWARE_PATH}/.." \
         -libraries "${ROOT}" \
 		    ${EXTRA_BUILDER_ARGS} \

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -253,6 +253,10 @@ ROOT="$(cd $(dirname $0)/..; pwd)"
 export ROOT
 export SOURCEDIR="$(pwd)"
 
+if [ -e "${HOME}/.keyboardio-builder.conf" ]; then
+    . "${HOME}/.keyboardio-builder.conf"
+fi
+
 if [ -e "${SOURCEDIR}/.keyboardio-builder.conf" ]; then
     . "${SOURCEDIR}/.keyboardio-builder.conf"
 fi

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -40,6 +40,13 @@ submodule_update () {
 }
 
 find_sketch () {
+    if [ -e "${SOURCEDIR}/.keyboardio-builder.conf" ]; then
+        . "${SOURCEDIR}/.keyboardio-builder.conf"
+    fi
+
+    SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
+    LIBRARY="${LIBRARY:-${SKETCH}}"
+
     for path in "hardware/keyboardio/avr/libraries/Akela-${LIBRARY}/examples/${SKETCH}" \
                     "examples/${LIBRARY}" \
                     "src"; do
@@ -58,9 +65,46 @@ flash () {
     echo "Press ENTER when ready..."
     read a
 
-    stty -F /dev/ttyACM* 1200 hupcl
+    reset_device
     sleep 3s
-    avrdude -q -q -patmega32u4 -cavr109 -D -P /dev/ttyACM* -b57600 "-Uflash:w:${OUTPUT_PATH}/${SKETCH}-latest.hex:i"
+    avrdude -q -q -p${MCU} -cavr109 -D -P ${DEVICE_PORT_BOOTLOADER} -b57600 "-Uflash:w:${HEX_FILE_PATH}:i"
+
+    cd "${SOURCEDIR}"
+}
+
+program () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    echo "Press ENTER when ready..."
+    read a
+
+    avrdude -v \
+		        -p${MCU} \
+		        -cusbtiny \
+		        -D \
+		        -B 1 \
+		        "-Uflash:w:${HEX_FILE_PATH}:i"
+
+    cd "${SOURCEDIR}"
+}
+
+hex_with_bootloader () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+	  cat ${HEX_FILE_PATH} | awk '/^:00000001FF/ == 0' > ${HEX_FILE_WITH_BOOTLOADER_PATH}
+	  echo "Using ${BOOTLOADER_PATH}"
+	  ${MD5} ${BOOTLOADER_PATH}
+	  cat ${BOOTLOADER_PATH} >> ${HEX_FILE_WITH_BOOTLOADER_PATH}
+    cat <<EOF
+
+Combined firmware and bootloader are now at ${HEX_FILE_WITH_BOOTLOADER_PATH}
+Make sure you have the bootloader version you expect.
+
+And TEST THIS ON REAL HARDWARE BEFORE YOU GIVE IT TO ANYONE
+
+EOF
 
     cd "${SOURCEDIR}"
 }
@@ -78,6 +122,8 @@ compile () {
 
     echo "Building ${OUTPUT_DIR}/${SKETCH} (${LIB_VERSION}) ..."
 
+    ${compile_HOOKS}
+
     ${ARDUINO_BUILDER} \
         -compile \
 		    -hardware "${ARDUINO_PATH}/hardware" \
@@ -85,7 +131,7 @@ compile () {
 		    ${ARDUINO_TOOLS_PARAM} \
 		    -tools "${ARDUINO_PATH}/tools-builder" \
 		    -fqbn "${FQBN}" \
-		    -libraries "${ROOT}/libraries" \
+		    -libraries "${ARDUINO_LOCAL_LIB_PATH}/libraries" \
 		    -libraries "${BOARD_HARDWARE_PATH}/.." \
         -libraries "${ROOT}" \
 		    ${EXTRA_BUILDER_ARGS} \
@@ -149,11 +195,29 @@ size_map () {
     cd "${SOURCEDIR}"
 }
 
+decompile () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    "${AVR_OBJDUMP}" -d "${ELF_FILE_PATH}"
+
+    cd "${SOURCEDIR}"
+}
+
 clean () {
     cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     rm -rf "${OUTPUT_PATH}"
+
+    cd "${SOURCEDIR}"
+}
+
+reset_device () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    ${RESET_DEVICE}
 
     cd "${SOURCEDIR}"
 }
@@ -184,6 +248,12 @@ Available commands:
   size-map
     Displays the size map for the sketch.
 
+  decomple
+    Decompile the sketch.
+
+  reset-device
+    Reset the device.
+
   flash
     Flashes the firmware using avrdude.
 
@@ -212,10 +282,8 @@ ROOT="$(cd $(dirname $0)/..; pwd)"
 export ROOT
 export SOURCEDIR="$(pwd)"
 
-if [ $# -eq 1 ]; then
-    cmd="$(echo $1 | tr '-' '_')"
-    ${cmd}
-    exit $?
+if [ -e "${SOURCEDIR}/.keyboardio-builder.conf" ]; then
+    . "${SOURCEDIR}/.keyboardio-builder.conf"
 fi
 
 cmds=""
@@ -237,8 +305,18 @@ done
 
 set -- ${cmds}
 
+if [ $# -eq 1 ]; then
+    cmd="$(echo $1 | tr '-' '_')"
+    ${cmd}
+    exit $?
+fi
+
 SKETCH="$1"
 shift
+
+if [ "${SKETCH}" = "default" ]; then
+    SKETCH="${DEFAULT_SKETCH}"
+fi
 
 cmds=""
 

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -108,7 +108,7 @@ EOF
 
 build () {
     compile $@
-    report_size $@
+    size $@
 }
 
 compile () {
@@ -173,7 +173,7 @@ build_all () {
     done
 }
 
-report_size () {
+size () {
     . ${ROOT}/tools/settings.sh
 
     if [ ! -e "${HEX_FILE_PATH}" ]; then
@@ -231,7 +231,7 @@ Available commands:
   compile
     Compiles the sketch.
 
-  report-size
+  size
     Reports the size of the compiled sketch.
 
   build

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -55,6 +55,10 @@ find_sketch () {
 flash () {
     . ${ROOT}/tools/settings.sh
 
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
+
     echo "Press ENTER when ready..."
     read a
 
@@ -65,6 +69,10 @@ flash () {
 
 program () {
     . ${ROOT}/tools/settings.sh
+
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
 
     echo "Press ENTER when ready..."
     read a
@@ -79,6 +87,10 @@ program () {
 
 hex_with_bootloader () {
     . ${ROOT}/tools/settings.sh
+
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
 
 	  cat ${HEX_FILE_PATH} | awk '/^:00000001FF/ == 0' > ${HEX_FILE_WITH_BOOTLOADER_PATH}
 	  echo "Using ${BOOTLOADER_PATH}"
@@ -164,6 +176,10 @@ build_all () {
 report_size () {
     . ${ROOT}/tools/settings.sh
 
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
+
 	  echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
 	  firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
 	  echo
@@ -172,11 +188,19 @@ report_size () {
 size_map () {
     . ${ROOT}/tools/settings.sh
 
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
+
     "${AVR_NM}" --size-sort -C -r -l "${ELF_FILE_PATH}"
 }
 
 decompile () {
     . ${ROOT}/tools/settings.sh
+
+    if [ ! -e "{HEX_FILE_PATH}" ]; then
+        compile
+    fi
 
     "${AVR_OBJDUMP}" -d "${ELF_FILE_PATH}"
 }

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -11,13 +11,7 @@ firmware_size () {
 
 	PROGSIZE="$(echo "${output}" | grep Program: | cut -d: -f2 | awk '{print $1}')"
 
-	PERCENT=$(cat <<EOF
-scale=2
-${PROGSIZE} / ${MAX_PROG_SIZE} * 100
-EOF
-	)
-
-	PERCENT=$(printf %02.01f $(echo "${PERCENT}" | bc -q))
+  PERCENT="$(echo ${PROGSIZE} ${MAX_PROG_SIZE} | awk "{ printf \"%02.01f\", \$1 / \$2 * 100 }")"
 
 	echo "${output}" | sed -e "s,\(Program:.*\)(\([0-9\.]*%\) Full),\1(${PERCENT}% Full),"
 }

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -1,0 +1,257 @@
+#! /bin/sh
+
+set -e
+
+firmware_size () {
+	## This is a terrible hack, please don't hurt me. - algernon
+
+	MAX_PROG_SIZE=28672
+
+	output="$($@ | grep "\\(Program\\|Data\\):" | sed -e 's,^,  - ,' && echo)"
+
+	PROGSIZE="$(echo "${output}" | grep Program: | cut -d: -f2 | awk '{print $1}')"
+
+	PERCENT=$(cat <<EOF
+scale=2
+${PROGSIZE} / ${MAX_PROG_SIZE} * 100
+EOF
+	)
+
+	PERCENT=$(printf %02.01f $(echo "${PERCENT}" | bc -q))
+
+	echo "${output}" | sed -e "s,\(Program:.*\)(\([0-9\.]*%\) Full),\1(${PERCENT}% Full),"
+}
+
+submodule_update () {
+    cd $(dirname $0)/..
+
+    echo Syncing submodules...
+    git submodule --quiet sync --recursive
+
+    echo Updating submodules...
+    git submodule --quiet update --init --recursive
+
+    echo
+
+    for lib in hardware/keyboardio/avr/libraries/* lib/*; do
+        echo Updating $(basename ${lib})...
+        (cd $lib; git checkout -q master; git pull -q --ff)
+    done
+}
+
+find_sketch () {
+    for path in "hardware/keyboardio/avr/libraries/Akela-${LIBRARY}/examples/${SKETCH}" \
+                    "examples/${LIBRARY}" \
+                    "src"; do
+        if [ -f "${path}/${SKETCH}.ino" ]; then
+            echo "${path}"
+            return
+        fi
+    done
+    exit 1
+}
+
+flash () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    echo "Press ENTER when ready..."
+    read a
+
+    stty -F /dev/ttyACM* 1200 hupcl
+    sleep 3s
+    avrdude -q -q -patmega32u4 -cavr109 -D -P /dev/ttyACM* -b57600 "-Uflash:w:${OUTPUT_PATH}/${SKETCH}-latest.hex:i"
+
+    cd "${SOURCEDIR}"
+}
+
+build () {
+    compile $@
+    report_size $@
+}
+
+compile () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    install -d "${OUTPUT_PATH}"
+
+    echo "Building ${OUTPUT_DIR}/${SKETCH} (${LIB_VERSION}) ..."
+
+    ${ARDUINO_BUILDER} \
+        -compile \
+		    -hardware "${ARDUINO_PATH}/hardware" \
+		    -hardware "${BOARD_HARDWARE_PATH}" \
+		    ${ARDUINO_TOOLS_PARAM} \
+		    -tools "${ARDUINO_PATH}/tools-builder" \
+		    -fqbn "${FQBN}" \
+		    -libraries "${ROOT}/libraries" \
+		    -libraries "${BOARD_HARDWARE_PATH}/.." \
+        -libraries "${ROOT}" \
+		    ${EXTRA_BUILDER_ARGS} \
+		    -build-path "${BUILD_PATH}" \
+		    -ide-version "${ARDUINO_IDE_VERSION}" \
+		    -warnings all \
+        ${ARDUINO_VERBOSE} \
+		    -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers" \
+		    ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
+		    "${SKETCH}.ino"
+
+    cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
+    cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"
+    ln -sf "${OUTPUT_FILE_PREFIX}.hex" "${OUTPUT_PATH}/${SKETCH}-latest.hex"
+    ln -sf "${OUTPUT_FILE_PREFIX}.elf" "${OUTPUT_PATH}/${SKETCH}-latest.elf"
+	  rm -rf "${BUILD_PATH}"
+
+    cd "${SOURCEDIR}"
+}
+
+_find_all () {
+    for plugin in hardware/keyboardio/avr/libraries/Akela-*/examples/* \
+                      examples/* \
+                      src/*.ino; do
+        if [ -d "$(dirname ${plugin})" ] || [ -f "${plugin}" ]; then
+            p="$(basename "${plugin}" .ino)"
+            if [ "${p}" != '*' ]; then
+                echo "${p}"
+            fi
+        fi
+    done | sort
+}
+
+build_all () {
+    plugins="$(_find_all)"
+
+    for plugin in ${plugins}; do
+        export SKETCH="${plugin}"
+        export LIBRARY="${plugin}"
+        (build ${plugin})
+    done
+}
+
+report_size () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+	  echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
+	  firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
+	  echo
+
+    cd "${SOURCEDIR}"
+}
+
+size_map () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    "${AVR_NM}" --size-sort -C -r -l "${ELF_FILE_PATH}"
+
+    cd "${SOURCEDIR}"
+}
+
+clean () {
+    cd "$(find_sketch)"
+    . ${ROOT}/tools/settings.sh
+
+    rm -rf "${OUTPUT_PATH}"
+
+    cd "${SOURCEDIR}"
+}
+
+usage () {
+    cat <<EOF
+Usage: $0 SKETCH commands...
+
+Runs all of the commands in the context of the Sketch.
+
+Available commands:
+
+  help
+    This help screen.
+
+  compile
+    Compiles the sketch.
+
+  report-size
+    Reports the size of the compiled sketch.
+
+  build
+    Runs compile and report-size.
+
+  clean
+    Cleans up the output directory.
+
+  size-map
+    Displays the size map for the sketch.
+
+  flash
+    Flashes the firmware using avrdude.
+
+  build-all
+    Build all Sketches we can find.
+EOF
+}
+
+help () {
+    usage
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+## Parse the command-line
+##  - anything that has a =, is an env var
+##  - from the remaining stuff, the first one is the Library/Sketch
+##  - everything else are commands
+##
+##  - if there is only one argument, that's a command
+
+ROOT="$(cd $(dirname $0)/..; pwd)"
+export ROOT
+export SOURCEDIR="$(pwd)"
+
+if [ $# -eq 1 ]; then
+    cmd="$(echo $1 | tr '-' '_')"
+    ${cmd}
+    exit $?
+fi
+
+cmds=""
+
+## Export vars
+for i in $(seq 1 $#); do
+    v="$1"
+    shift
+
+    case "${v}" in
+        *=*)
+            export ${v}
+            ;;
+        *)
+            cmds="${cmds} ${v}"
+            ;;
+    esac
+done
+
+set -- ${cmds}
+
+SKETCH="$1"
+shift
+
+cmds=""
+
+for i in $(seq 1 $#); do
+    cmds="${cmds} $(echo $1 | tr '-' '_')"
+    shift
+done
+
+LIBRARY="${SKETCH}"
+
+export SKETCH
+export LIBRARY
+
+for cmd in ${cmds}; do
+    ${cmd}
+done

--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -59,7 +59,6 @@ find_sketch () {
 }
 
 flash () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     echo "Press ENTER when ready..."
@@ -68,12 +67,9 @@ flash () {
     reset_device
     sleep 3s
     avrdude -q -q -p${MCU} -cavr109 -D -P ${DEVICE_PORT_BOOTLOADER} -b57600 "-Uflash:w:${HEX_FILE_PATH}:i"
-
-    cd "${SOURCEDIR}"
 }
 
 program () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     echo "Press ENTER when ready..."
@@ -85,12 +81,9 @@ program () {
 		        -D \
 		        -B 1 \
 		        "-Uflash:w:${HEX_FILE_PATH}:i"
-
-    cd "${SOURCEDIR}"
 }
 
 hex_with_bootloader () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
 	  cat ${HEX_FILE_PATH} | awk '/^:00000001FF/ == 0' > ${HEX_FILE_WITH_BOOTLOADER_PATH}
@@ -105,8 +98,6 @@ Make sure you have the bootloader version you expect.
 And TEST THIS ON REAL HARDWARE BEFORE YOU GIVE IT TO ANYONE
 
 EOF
-
-    cd "${SOURCEDIR}"
 }
 
 build () {
@@ -115,7 +106,6 @@ build () {
 }
 
 compile () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     install -d "${OUTPUT_PATH}"
@@ -141,15 +131,13 @@ compile () {
         ${ARDUINO_VERBOSE} \
 		    -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers" \
 		    ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
-		    "${SKETCH}.ino"
+		    "$(find_sketch)/${SKETCH}.ino"
 
     cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
     cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"
     ln -sf "${OUTPUT_FILE_PREFIX}.hex" "${OUTPUT_PATH}/${SKETCH}-latest.hex"
     ln -sf "${OUTPUT_FILE_PREFIX}.elf" "${OUTPUT_PATH}/${SKETCH}-latest.elf"
 	  rm -rf "${BUILD_PATH}"
-
-    cd "${SOURCEDIR}"
 }
 
 _find_all () {
@@ -176,50 +164,35 @@ build_all () {
 }
 
 report_size () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
 	  echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
 	  firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
 	  echo
-
-    cd "${SOURCEDIR}"
 }
 
 size_map () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     "${AVR_NM}" --size-sort -C -r -l "${ELF_FILE_PATH}"
-
-    cd "${SOURCEDIR}"
 }
 
 decompile () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     "${AVR_OBJDUMP}" -d "${ELF_FILE_PATH}"
-
-    cd "${SOURCEDIR}"
 }
 
 clean () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     rm -rf "${OUTPUT_PATH}"
-
-    cd "${SOURCEDIR}"
 }
 
 reset_device () {
-    cd "$(find_sketch)"
     . ${ROOT}/tools/settings.sh
 
     ${RESET_DEVICE}
-
-    cd "${SOURCEDIR}"
 }
 
 usage () {

--- a/tools/settings.sh
+++ b/tools/settings.sh
@@ -44,8 +44,8 @@ BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
 OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
 OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
 
-GIT_VERSION="$(git describe --abbrev=4 --dirty --always)"
-LIB_VERSION="$( (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
+LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
 OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
 

--- a/tools/settings.sh
+++ b/tools/settings.sh
@@ -1,0 +1,59 @@
+## NEEDS: LIBRARY, SKETCH, ROOT, SOURCEDIR
+## Should be included when the current directory is the dir of the Sketch.
+
+if [ -z "${SKETCH}" ] || [ -z "${LIBRARY}" ] || [ -z "${ROOT}" ] || [ -z "${SOURCEDIR}" ]; then
+    echo "SKETCH, LIBRARY, SOURCEDIR, and ROOT need to be set before including this file!" >&2
+    exit 1
+fi
+
+case "$0" in
+    */settings.sh)
+        echo "This file must be included, never run directly!" >&2
+        exit 1
+        ;;
+esac
+
+if [ -e "${SOURCEDIR}/settings.sh" ]; then
+   . "${SOURCEDIR}/settings.sh"
+fi
+
+BOARD="model01"
+MCU="atmega32u4"
+FQBN="keyboardio:avr:model01"
+
+ARDUINO_PATH="${ARDUINO_PATH:-${HOME}/install/arduino}"
+ARDUINO_TOOLS_PATH="${ARDUINO_TOOLS_PATH:-${ARDUINO_PATH}/hardware/tools}"
+ARDUINO_BUILDER="${ARDUINO_BUILDER:-${ARDUINO_PATH}/arduino-builder}"
+ARDUINO_IDE_VERSION="100607"
+
+BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ROOT}/hardware}"
+
+AVR_SIZE="${AVR_SIZE:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-size}"
+AVR_NM="${AVR_NM:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-nm}"
+
+BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
+OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
+OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
+
+GIT_VERSION="$(git describe --abbrev=4 --dirty --always)"
+LIB_VERSION="$( (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+
+OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
+
+HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
+ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
+
+ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
+if [ -z "${ARDUINO_TOOLS_PATH}" ]; then
+    ARDUINO_TOOLS_PARAM=""
+fi
+
+if [ ! -z "${AVR_GCC_PREFIX}" ]; then
+    ARDUINO_AVR_GCC_PREFIX_PARAM="-prefs \"runtime.tools.avr-gcc.path=${AVR_GCC_PREFIX}\""
+fi
+
+if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
+    ARDUINO_VERBOSE="-verbose"
+else
+    ARDUINO_VERBOSE="-quiet"
+fi

--- a/tools/settings.sh
+++ b/tools/settings.sh
@@ -1,11 +1,6 @@
 ## NEEDS: LIBRARY, SKETCH, ROOT, SOURCEDIR
 ## Should be included when the current directory is the dir of the Sketch.
 
-if [ -z "${SKETCH}" ] || [ -z "${LIBRARY}" ] || [ -z "${ROOT}" ] || [ -z "${SOURCEDIR}" ]; then
-    echo "SKETCH, LIBRARY, SOURCEDIR, and ROOT need to be set before including this file!" >&2
-    exit 1
-fi
-
 case "$0" in
     */settings.sh)
         echo "This file must be included, never run directly!" >&2
@@ -13,23 +8,37 @@ case "$0" in
         ;;
 esac
 
-if [ -e "${SOURCEDIR}/settings.sh" ]; then
-   . "${SOURCEDIR}/settings.sh"
+SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
+LIBRARY="${LIBRARY:-${SKETCH}}"
+
+if [ -z "${SKETCH}" ] || [ -z "${LIBRARY}" ] || [ -z "${ROOT}" ] || [ -z "${SOURCEDIR}" ]; then
+    echo "SKETCH, LIBRARY, SOURCEDIR, and ROOT need to be set before including this file!" >&2
+    exit 1
 fi
 
 BOARD="model01"
 MCU="atmega32u4"
 FQBN="keyboardio:avr:model01"
 
-ARDUINO_PATH="${ARDUINO_PATH:-${HOME}/install/arduino}"
+DEVICE_PORT="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
+DEVICE_PORT_BOOTLOADER="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
+
+RESET_BOARD="stty -F ${DEVICE_PORT} 1200 hupcl"
+
+ARDUINO_PATH="${ARDUINO_PATH:-/usr/local/arduino}"
+ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Arduino}"
 ARDUINO_TOOLS_PATH="${ARDUINO_TOOLS_PATH:-${ARDUINO_PATH}/hardware/tools}"
 ARDUINO_BUILDER="${ARDUINO_BUILDER:-${ARDUINO_PATH}/arduino-builder}"
 ARDUINO_IDE_VERSION="100607"
 
-BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ROOT}/hardware}"
+BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"
+BOOTLOADER_PATH="${BOARD_HARDWARE_PATH}/keyboardio/avr/bootloaders/caterina/Caterina.hex"
 
 AVR_SIZE="${AVR_SIZE:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-size}"
 AVR_NM="${AVR_NM:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-nm}"
+AVR_OBJDUMP="${AVR_OBJDUMP:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-objdump}"
+
+MD5="md5sum"
 
 BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
 OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
@@ -41,6 +50,7 @@ LIB_VERSION="$( (grep version= ../../library.properties 2>/dev/null || echo vers
 OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
 
 HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
+HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
 ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
 
 ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
@@ -56,4 +66,20 @@ if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
     ARDUINO_VERBOSE="-verbose"
 else
     ARDUINO_VERBOSE="-quiet"
+fi
+
+## Platform-specific overrides
+# Shamelessly stolen from git's Makefile
+uname_S=$(uname -s 2>/dev/null || echo not)
+
+if [ "${uname_S}" = "Darwin" ]; then
+    DEVICE_PORT="$(ls /dev/cu.usbmodemHID?? /dev/cu.usbmodem14*)"
+    DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodem14*)"
+
+    ARDUINO_PATH="/Applications/Arduino.app/Contents/Java/"
+    ARDUINO_LOCAL_LIB_PATH="${HOME}/Documents/Arduino"
+
+    MD5="md5"
+
+    RESET_BOARD="stty -f ${DEVICE_PORT} 1200"
 fi


### PR DESCRIPTION
The tool - a work in progress - is meant to eventually replace the Makefile. It is set up so that it can easily be reused by third-party libraries to build their own examples, with minimal amount of configuration.

The tool is not quite there yet, it can't do everything the Makefile does, it is not all that well documented, and so on. But it can do everything the old Makefile snippets in Akela could, and a bit more than that.

Try `tools/keyboardio-builder KeyboardioFirmware build size-map` for example! Or `tools/keyboardio-builder build-all`.

I'll be updating the script in the coming days, if you are okay with the direction. If/when this moves here, the Akela repo becomes kind of obsolete, as these are the only things left in there. And an example, but I can move that elsewhere.