### PR TITLE
Move the AppSwitcher example here from Akela

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - git submodule update --init --recursive
 - popd
 script:
-- make ARDUINO_PATH=../arduino-1.6.11 ARDUINO_LOCAL_LIB_PATH=../arduino-local
+- make ARDUINO_PATH=../arduino-1.6.11 ARDUINO_LOCAL_LIB_PATH=../arduino-local build-all
 notifications:
   irc:
     channels:

--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -1,0 +1,62 @@
+/* -*- mode: c++ -*-
+ * AppSwitcher -- A Keyboardio Example
+ * Copyright (C) 2016, 2017  Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Akela-HostOS.h"
+
+#include "Macros.h"
+
+const Key keymaps[][ROWS][COLS] PROGMEM = {
+  [0] = KEYMAP_STACKED
+  (
+   Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDn,        Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc,
+
+   Key_LCtrl, Key_Backspace, Key_LGUI, Key_LShift,
+   M(M_APPSWITCH),
+
+   Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+   Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+              Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+   Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+   Key_RShift, Key_RAlt, Key_Space, Key_RCtrl,
+   M(M_APPCANCEL)
+   ),
+};
+
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+  switch (macroIndex) {
+  case M_APPSWITCH:
+    return macroAppSwitch (keyState);
+  case M_APPCANCEL:
+    return macroAppCancel (keyState);
+  }
+  return MACRO_NONE;
+}
+
+void setup () {
+  Keyboardio.setup (KEYMAP_SIZE);
+  Keyboardio.use (&HostOS, &Macros, NULL);
+}
+
+void loop () {
+  Keyboardio.loop ();
+}

--- a/examples/AppSwitcher/Macros.cpp
+++ b/examples/AppSwitcher/Macros.cpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++ -*-
+ * AppSwitcher -- A Keyboardio Example
+ * Copyright (C) 2016, 2017  Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#define AKELA_HOSTOS_GUESSER 1
+
+#include <Akela-HostOS.h>
+
+#include "Macros.h"
+
+using namespace Akela::HostOS;
+
+static bool appSwitchActive = false;
+
+const macro_t *macroAppSwitch (uint8_t keyState) {
+  Key mod = Key_LAlt;
+
+  if (HostOS.os () == OSX)
+    mod = Key_LGUI;
+
+  // Key was just pressed, or is being held
+  if (key_is_pressed(keyState)) {
+    return MACRO(Dr(mod), D(Tab), END);
+  }
+  // Key was just released
+  if (key_toggled_off(keyState)) {
+    return MACRO(U(Tab), Dr(mod), END);
+  }
+  // Key is not pressed, and was not just released.
+  // if appSwitchActive is true, we continue holding Alt.
+  if (appSwitchActive) {
+    return MACRO(Dr(mod), END);
+  }
+  // otherwise we do nothing
+  return MACRO_NONE;
+}
+
+const macro_t *macroAppCancel (uint8_t keyState) {
+  if (key_toggled_on (keyState))
+    appSwitchActive = false;
+  return MACRO_NONE;
+}

--- a/examples/AppSwitcher/Macros.h
+++ b/examples/AppSwitcher/Macros.h
@@ -1,0 +1,30 @@
+/* -*- mode: c++ -*-
+ * AppSwitcher -- A Keyboardio Example
+ * Copyright (C) 2016, 2017  Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <Keyboardio-Macros.h>
+
+enum {
+  M_APPSWITCH,
+  M_APPCANCEL,
+};
+
+const macro_t *macroAppSwitch (uint8_t keyState);
+const macro_t *macroAppCancel (uint8_t keyState);


### PR DESCRIPTION
Does as the title suggests, and also switches Travis to use `make build-all`, so both current examples will build, and any future ones will automatically build, too.