### PR TITLE
Swap flags and keyCode in the Key struct

### DIFF
--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -5,8 +5,8 @@
 typedef union Key_ {
 
     struct {
-        uint8_t flags;
         uint8_t keyCode;
+        uint8_t flags;
     };
     uint16_t raw;
 
@@ -68,195 +68,195 @@ typedef union Key_ {
 #define KEYMAP_NEXT      34
 
 
-#define Key_NoKey (Key){ KEY_FLAGS,0 }
-#define Key_skip (Key){ KEY_FLAGS,0 }
+#define Key_NoKey (Key) { 0,  KEY_FLAGS }
+#define Key_skip (Key) { 0,  KEY_FLAGS }
 #define Key_Transparent (Key){ .raw = 0xffff }
 #define ___ Key_Transparent
 #define XXX Key_NoKey
 
 
-#define Key_powerDown (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_POWER_DOWN }
-#define Key_sleep (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_SLEEP }
-#define Key_wakeup (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_WAKEUP }
-#define Key_coldRestart (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_COLD_RESTART }
-#define Key_warmRestart (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_WARM_RESTART }
-#define Key_dock (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DOCK }
-#define Key_undock (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_UNDOCK }
-#define Key_speakerMute (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_SPEAKER_MUTE }
-#define Key_hibernate (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_HIBERNATE }
-#define Key_displayInvert (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_INVERT }
-#define Key_displayInternal (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_INTERNAL }
-#define Key_displayExternal (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_EXTERNAL }
-#define Key_displayBoth (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_BOTH }
-#define Key_displayDual (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_DUAL }
+#define Key_powerDown (Key) { HID_SYSTEM_POWER_DOWN, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_sleep (Key) { HID_SYSTEM_SLEEP, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_wakeup (Key) { HID_SYSTEM_WAKEUP, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_coldRestart (Key) { HID_SYSTEM_COLD_RESTART, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_warmRestart (Key) { HID_SYSTEM_WARM_RESTART, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_dock (Key) { HID_SYSTEM_DOCK, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_undock (Key) { HID_SYSTEM_UNDOCK, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_speakerMute (Key) { HID_SYSTEM_SPEAKER_MUTE, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_hibernate (Key) { HID_SYSTEM_HIBERNATE, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_displayInvert (Key) { HID_SYSTEM_DISPLAY_INVERT, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_displayInternal (Key) { HID_SYSTEM_DISPLAY_INTERNAL, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_displayExternal (Key) { HID_SYSTEM_DISPLAY_EXTERNAL, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_displayBoth (Key) { HID_SYSTEM_DISPLAY_BOTH, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
+#define Key_displayDual (Key) { HID_SYSTEM_DISPLAY_DUAL, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
 #define Key_displayToggle (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_TOGGLE_INT_EXT
-#define Key_displaySwap (Key) {KEY_FLAGS | SYNTHETIC|IS_SYSCTL,HID_SYSTEM_DISPLAY_SWAP }
+#define Key_displaySwap (Key) { HID_SYSTEM_DISPLAY_SWAP, KEY_FLAGS | SYNTHETIC|IS_SYSCTL }
 
 
-#define Key_volumeMute (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_MUTE}
-#define Key_volumeUp (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_VOLUME_INCREMENT }
-#define Key_volumeDown (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_VOLUME_DECREMENT }
-#define Key_playPause (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_PLAY_SLASH_PAUSE}
-#define Key_stop (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_STOP}
-#define Key_prevTrack (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_SCAN_PREVIOUS_TRACK}
-#define Key_nextTrack (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_SCAN_NEXT_TRACK}
-#define Key_Eject (Key) {KEY_FLAGS | SYNTHETIC|IS_CONSUMER, HID_CONSUMER_EJECT}
+#define Key_volumeMute (Key) { HID_CONSUMER_MUTE, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_volumeUp (Key) { HID_CONSUMER_VOLUME_INCREMENT, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_volumeDown (Key) { HID_CONSUMER_VOLUME_DECREMENT, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_playPause (Key) { HID_CONSUMER_PLAY_SLASH_PAUSE, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_stop (Key) { HID_CONSUMER_STOP, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_prevTrack (Key) { HID_CONSUMER_SCAN_PREVIOUS_TRACK, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_nextTrack (Key) { HID_CONSUMER_SCAN_NEXT_TRACK, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
+#define Key_Eject (Key) { HID_CONSUMER_EJECT, KEY_FLAGS | SYNTHETIC|IS_CONSUMER }
 
 
-#define Key_LCtrl (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_CONTROL }
-#define Key_LShift (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_SHIFT }
-#define Key_LAlt (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_ALT }
-#define Key_LGUI (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_GUI }
-#define Key_RCtrl (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_CONTROL }
-#define Key_RShift (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_SHIFT }
-#define Key_RAlt (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_ALT }
-#define Key_RGUI (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_GUI }
+#define Key_LCtrl (Key) { HID_KEYBOARD_LEFT_CONTROL,  KEY_FLAGS }
+#define Key_LShift (Key) { HID_KEYBOARD_LEFT_SHIFT,  KEY_FLAGS }
+#define Key_LAlt (Key) { HID_KEYBOARD_LEFT_ALT,  KEY_FLAGS }
+#define Key_LGUI (Key) { HID_KEYBOARD_LEFT_GUI,  KEY_FLAGS }
+#define Key_RCtrl (Key) { HID_KEYBOARD_RIGHT_CONTROL,  KEY_FLAGS }
+#define Key_RShift (Key) { HID_KEYBOARD_RIGHT_SHIFT,  KEY_FLAGS }
+#define Key_RAlt (Key) { HID_KEYBOARD_RIGHT_ALT,  KEY_FLAGS }
+#define Key_RGUI (Key) { HID_KEYBOARD_RIGHT_GUI,  KEY_FLAGS }
 
-#define Key_UpArrow (Key){ KEY_FLAGS, HID_KEYBOARD_UP_ARROW }
-#define Key_DnArrow (Key){ KEY_FLAGS, HID_KEYBOARD_DOWN_ARROW }
-#define Key_LArrow (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_ARROW  }
-#define Key_RArrow (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_ARROW}
-#define Key_Return (Key){ KEY_FLAGS, HID_KEYBOARD_RETURN }
-#define Key_Esc (Key){ KEY_FLAGS, HID_KEYBOARD_ESCAPE }
-#define Key_Backspace (Key){ KEY_FLAGS, HID_KEYBOARD_DELETE }
-#define Key_Tab (Key){ KEY_FLAGS, HID_KEYBOARD_TAB }
-#define Key_Insert (Key){ KEY_FLAGS, HID_KEYBOARD_INSERT }
-#define Key_Delete (Key){ KEY_FLAGS, HID_KEYBOARD_DELETE_FORWARD }
-#define Key_PageUp (Key){ KEY_FLAGS, HID_KEYBOARD_PAGE_UP }
-#define Key_PageDn (Key){ KEY_FLAGS, HID_KEYBOARD_PAGE_DOWN }
-#define Key_Home (Key){ KEY_FLAGS, HID_KEYBOARD_HOME }
-#define Key_End (Key){ KEY_FLAGS, HID_KEYBOARD_END }
-
-
-#define Key_CapsLock (Key){ KEY_FLAGS, HID_KEYBOARD_CAPS_LOCK }
-
-#define Key_F1 (Key){ KEY_FLAGS, HID_KEYBOARD_F1 }
-#define Key_F2 (Key){ KEY_FLAGS, HID_KEYBOARD_F2 }
-#define Key_F3 (Key){ KEY_FLAGS, HID_KEYBOARD_F3 }
-#define Key_F4 (Key){ KEY_FLAGS, HID_KEYBOARD_F4 }
-#define Key_F5 (Key){ KEY_FLAGS, HID_KEYBOARD_F5 }
-#define Key_F6 (Key){ KEY_FLAGS, HID_KEYBOARD_F6 }
-#define Key_F7 (Key){ KEY_FLAGS, HID_KEYBOARD_F7 }
-#define Key_F8 (Key){ KEY_FLAGS, HID_KEYBOARD_F8 }
-#define Key_F9 (Key){ KEY_FLAGS, HID_KEYBOARD_F9 }
-#define Key_F10 (Key){ KEY_FLAGS, HID_KEYBOARD_F10 }
-#define Key_F11 (Key){ KEY_FLAGS, HID_KEYBOARD_F11 }
-#define Key_F12 (Key){ KEY_FLAGS, HID_KEYBOARD_F12 }
-#define Key_F13 (Key){ KEY_FLAGS, HID_KEYBOARD_F13 }
-#define Key_F14 (Key){ KEY_FLAGS, HID_KEYBOARD_F14 }
-#define Key_F15 (Key){ KEY_FLAGS, HID_KEYBOARD_F15 }
-#define Key_F16 (Key){ KEY_FLAGS, HID_KEYBOARD_F16 }
-#define Key_F17 (Key){ KEY_FLAGS, HID_KEYBOARD_F17 }
-#define Key_F18 (Key){ KEY_FLAGS, HID_KEYBOARD_F18 }
-#define Key_F19 (Key){ KEY_FLAGS, HID_KEYBOARD_F19 }
-#define Key_F20 (Key){ KEY_FLAGS, HID_KEYBOARD_F20 }
-#define Key_F21 (Key){ KEY_FLAGS, HID_KEYBOARD_F21 }
-#define Key_F22 (Key){ KEY_FLAGS, HID_KEYBOARD_F22 }
-#define Key_F23 (Key){ KEY_FLAGS, HID_KEYBOARD_F23 }
-#define Key_F24 (Key){ KEY_FLAGS, HID_KEYBOARD_F24 }
+#define Key_UpArrow (Key) { HID_KEYBOARD_UP_ARROW,  KEY_FLAGS }
+#define Key_DnArrow (Key) { HID_KEYBOARD_DOWN_ARROW,  KEY_FLAGS }
+#define Key_LArrow (Key) { HID_KEYBOARD_LEFT_ARROW,  KEY_FLAGS }
+#define Key_RArrow (Key) { HID_KEYBOARD_RIGHT_ARROW,  KEY_FLAGS }
+#define Key_Return (Key) { HID_KEYBOARD_RETURN,  KEY_FLAGS }
+#define Key_Esc (Key) { HID_KEYBOARD_ESCAPE,  KEY_FLAGS }
+#define Key_Backspace (Key) { HID_KEYBOARD_DELETE,  KEY_FLAGS }
+#define Key_Tab (Key) { HID_KEYBOARD_TAB,  KEY_FLAGS }
+#define Key_Insert (Key) { HID_KEYBOARD_INSERT,  KEY_FLAGS }
+#define Key_Delete (Key) { HID_KEYBOARD_DELETE_FORWARD,  KEY_FLAGS }
+#define Key_PageUp (Key) { HID_KEYBOARD_PAGE_UP,  KEY_FLAGS }
+#define Key_PageDn (Key) { HID_KEYBOARD_PAGE_DOWN,  KEY_FLAGS }
+#define Key_Home (Key) { HID_KEYBOARD_HOME,  KEY_FLAGS }
+#define Key_End (Key) { HID_KEYBOARD_END,  KEY_FLAGS }
 
 
+#define Key_CapsLock (Key) { HID_KEYBOARD_CAPS_LOCK,  KEY_FLAGS }
+
+#define Key_F1 (Key) { HID_KEYBOARD_F1,  KEY_FLAGS }
+#define Key_F2 (Key) { HID_KEYBOARD_F2,  KEY_FLAGS }
+#define Key_F3 (Key) { HID_KEYBOARD_F3,  KEY_FLAGS }
+#define Key_F4 (Key) { HID_KEYBOARD_F4,  KEY_FLAGS }
+#define Key_F5 (Key) { HID_KEYBOARD_F5,  KEY_FLAGS }
+#define Key_F6 (Key) { HID_KEYBOARD_F6,  KEY_FLAGS }
+#define Key_F7 (Key) { HID_KEYBOARD_F7,  KEY_FLAGS }
+#define Key_F8 (Key) { HID_KEYBOARD_F8,  KEY_FLAGS }
+#define Key_F9 (Key) { HID_KEYBOARD_F9,  KEY_FLAGS }
+#define Key_F10 (Key) { HID_KEYBOARD_F10,  KEY_FLAGS }
+#define Key_F11 (Key) { HID_KEYBOARD_F11,  KEY_FLAGS }
+#define Key_F12 (Key) { HID_KEYBOARD_F12,  KEY_FLAGS }
+#define Key_F13 (Key) { HID_KEYBOARD_F13,  KEY_FLAGS }
+#define Key_F14 (Key) { HID_KEYBOARD_F14,  KEY_FLAGS }
+#define Key_F15 (Key) { HID_KEYBOARD_F15,  KEY_FLAGS }
+#define Key_F16 (Key) { HID_KEYBOARD_F16,  KEY_FLAGS }
+#define Key_F17 (Key) { HID_KEYBOARD_F17,  KEY_FLAGS }
+#define Key_F18 (Key) { HID_KEYBOARD_F18,  KEY_FLAGS }
+#define Key_F19 (Key) { HID_KEYBOARD_F19,  KEY_FLAGS }
+#define Key_F20 (Key) { HID_KEYBOARD_F20,  KEY_FLAGS }
+#define Key_F21 (Key) { HID_KEYBOARD_F21,  KEY_FLAGS }
+#define Key_F22 (Key) { HID_KEYBOARD_F22,  KEY_FLAGS }
+#define Key_F23 (Key) { HID_KEYBOARD_F23,  KEY_FLAGS }
+#define Key_F24 (Key) { HID_KEYBOARD_F24,  KEY_FLAGS }
 
 
-#define Key_1 (Key){ KEY_FLAGS, HID_KEYBOARD_1_AND_EXCLAMATION_POINT }
-#define Key_2 (Key){ KEY_FLAGS, HID_KEYBOARD_2_AND_AT }
-#define Key_3 (Key){ KEY_FLAGS, HID_KEYBOARD_3_AND_POUND }
-#define Key_4 (Key){ KEY_FLAGS, HID_KEYBOARD_4_AND_DOLLAR }
-#define Key_5 (Key){ KEY_FLAGS, HID_KEYBOARD_5_AND_PERCENT }
-#define Key_6 (Key){ KEY_FLAGS, HID_KEYBOARD_6_AND_CARAT }
-#define Key_7 (Key){ KEY_FLAGS, HID_KEYBOARD_7_AND_AMPERSAND }
-#define Key_8 (Key){ KEY_FLAGS, HID_KEYBOARD_8_AND_ASTERISK }
-#define Key_9 (Key){ KEY_FLAGS, HID_KEYBOARD_9_AND_LEFT_PAREN }
-#define Key_0 (Key){ KEY_FLAGS, HID_KEYBOARD_0_AND_RIGHT_PAREN }
-#define Key_A (Key){ KEY_FLAGS, HID_KEYBOARD_A_AND_A }
-#define Key_B (Key){ KEY_FLAGS, HID_KEYBOARD_B_AND_B }
-#define Key_C (Key){ KEY_FLAGS, HID_KEYBOARD_C_AND_C }
-#define Key_D (Key){ KEY_FLAGS, HID_KEYBOARD_D_AND_D }
-#define Key_E (Key){ KEY_FLAGS, HID_KEYBOARD_E_AND_E }
-#define Key_F (Key){ KEY_FLAGS, HID_KEYBOARD_F_AND_F }
-#define Key_G (Key){ KEY_FLAGS, HID_KEYBOARD_G_AND_G }
-#define Key_H (Key){ KEY_FLAGS, HID_KEYBOARD_H_AND_H }
-#define Key_I (Key){ KEY_FLAGS, HID_KEYBOARD_I_AND_I }
-#define Key_J (Key){ KEY_FLAGS, HID_KEYBOARD_J_AND_J }
-#define Key_K (Key){ KEY_FLAGS, HID_KEYBOARD_K_AND_K }
-#define Key_L (Key){ KEY_FLAGS, HID_KEYBOARD_L_AND_L }
-#define Key_M (Key){ KEY_FLAGS, HID_KEYBOARD_M_AND_M }
-#define Key_N (Key){ KEY_FLAGS, HID_KEYBOARD_N_AND_N }
-#define Key_O (Key){ KEY_FLAGS, HID_KEYBOARD_O_AND_O }
-#define Key_P (Key){ KEY_FLAGS, HID_KEYBOARD_P_AND_P }
-#define Key_Q (Key){ KEY_FLAGS, HID_KEYBOARD_Q_AND_Q }
-#define Key_R (Key){ KEY_FLAGS, HID_KEYBOARD_R_AND_R }
-#define Key_S (Key){ KEY_FLAGS, HID_KEYBOARD_S_AND_S }
-#define Key_T (Key){ KEY_FLAGS, HID_KEYBOARD_T_AND_T }
-#define Key_U (Key){ KEY_FLAGS, HID_KEYBOARD_U_AND_U }
-#define Key_V (Key){ KEY_FLAGS, HID_KEYBOARD_V_AND_V }
-#define Key_W (Key){ KEY_FLAGS, HID_KEYBOARD_W_AND_W }
-#define Key_X (Key){ KEY_FLAGS, HID_KEYBOARD_X_AND_X }
-#define Key_Y (Key){ KEY_FLAGS, HID_KEYBOARD_Y_AND_Y }
-#define Key_Z (Key){ KEY_FLAGS, HID_KEYBOARD_Z_AND_Z }
 
-#define Key_Backtick (Key){ KEY_FLAGS, HID_KEYBOARD_GRAVE_ACCENT_AND_TILDE }
-#define Key_Minus (Key){ KEY_FLAGS, HID_KEYBOARD_MINUS_AND_UNDERSCORE }
-#define Key_Equals (Key){ KEY_FLAGS, HID_KEYBOARD_EQUALS_AND_PLUS }
-#define Key_LBracket (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_BRACKET_AND_LEFT_CURLY_BRACE }
-#define Key_RBracket (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_CURLY_BRACE }
-#define Key_Backslash (Key){ KEY_FLAGS, HID_KEYBOARD_BACKSLASH_AND_PIPE }
+
+#define Key_1 (Key) { HID_KEYBOARD_1_AND_EXCLAMATION_POINT,  KEY_FLAGS }
+#define Key_2 (Key) { HID_KEYBOARD_2_AND_AT,  KEY_FLAGS }
+#define Key_3 (Key) { HID_KEYBOARD_3_AND_POUND,  KEY_FLAGS }
+#define Key_4 (Key) { HID_KEYBOARD_4_AND_DOLLAR,  KEY_FLAGS }
+#define Key_5 (Key) { HID_KEYBOARD_5_AND_PERCENT,  KEY_FLAGS }
+#define Key_6 (Key) { HID_KEYBOARD_6_AND_CARAT,  KEY_FLAGS }
+#define Key_7 (Key) { HID_KEYBOARD_7_AND_AMPERSAND,  KEY_FLAGS }
+#define Key_8 (Key) { HID_KEYBOARD_8_AND_ASTERISK,  KEY_FLAGS }
+#define Key_9 (Key) { HID_KEYBOARD_9_AND_LEFT_PAREN,  KEY_FLAGS }
+#define Key_0 (Key) { HID_KEYBOARD_0_AND_RIGHT_PAREN,  KEY_FLAGS }
+#define Key_A (Key) { HID_KEYBOARD_A_AND_A,  KEY_FLAGS }
+#define Key_B (Key) { HID_KEYBOARD_B_AND_B,  KEY_FLAGS }
+#define Key_C (Key) { HID_KEYBOARD_C_AND_C,  KEY_FLAGS }
+#define Key_D (Key) { HID_KEYBOARD_D_AND_D,  KEY_FLAGS }
+#define Key_E (Key) { HID_KEYBOARD_E_AND_E,  KEY_FLAGS }
+#define Key_F (Key) { HID_KEYBOARD_F_AND_F,  KEY_FLAGS }
+#define Key_G (Key) { HID_KEYBOARD_G_AND_G,  KEY_FLAGS }
+#define Key_H (Key) { HID_KEYBOARD_H_AND_H,  KEY_FLAGS }
+#define Key_I (Key) { HID_KEYBOARD_I_AND_I,  KEY_FLAGS }
+#define Key_J (Key) { HID_KEYBOARD_J_AND_J,  KEY_FLAGS }
+#define Key_K (Key) { HID_KEYBOARD_K_AND_K,  KEY_FLAGS }
+#define Key_L (Key) { HID_KEYBOARD_L_AND_L,  KEY_FLAGS }
+#define Key_M (Key) { HID_KEYBOARD_M_AND_M,  KEY_FLAGS }
+#define Key_N (Key) { HID_KEYBOARD_N_AND_N,  KEY_FLAGS }
+#define Key_O (Key) { HID_KEYBOARD_O_AND_O,  KEY_FLAGS }
+#define Key_P (Key) { HID_KEYBOARD_P_AND_P,  KEY_FLAGS }
+#define Key_Q (Key) { HID_KEYBOARD_Q_AND_Q,  KEY_FLAGS }
+#define Key_R (Key) { HID_KEYBOARD_R_AND_R,  KEY_FLAGS }
+#define Key_S (Key) { HID_KEYBOARD_S_AND_S,  KEY_FLAGS }
+#define Key_T (Key) { HID_KEYBOARD_T_AND_T,  KEY_FLAGS }
+#define Key_U (Key) { HID_KEYBOARD_U_AND_U,  KEY_FLAGS }
+#define Key_V (Key) { HID_KEYBOARD_V_AND_V,  KEY_FLAGS }
+#define Key_W (Key) { HID_KEYBOARD_W_AND_W,  KEY_FLAGS }
+#define Key_X (Key) { HID_KEYBOARD_X_AND_X,  KEY_FLAGS }
+#define Key_Y (Key) { HID_KEYBOARD_Y_AND_Y,  KEY_FLAGS }
+#define Key_Z (Key) { HID_KEYBOARD_Z_AND_Z,  KEY_FLAGS }
+
+#define Key_Backtick (Key) { HID_KEYBOARD_GRAVE_ACCENT_AND_TILDE,  KEY_FLAGS }
+#define Key_Minus (Key) { HID_KEYBOARD_MINUS_AND_UNDERSCORE,  KEY_FLAGS }
+#define Key_Equals (Key) { HID_KEYBOARD_EQUALS_AND_PLUS,  KEY_FLAGS }
+#define Key_LBracket (Key) { HID_KEYBOARD_LEFT_BRACKET_AND_LEFT_CURLY_BRACE,  KEY_FLAGS }
+#define Key_RBracket (Key) { HID_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_CURLY_BRACE,  KEY_FLAGS }
+#define Key_Backslash (Key) { HID_KEYBOARD_BACKSLASH_AND_PIPE,  KEY_FLAGS }
 #define Key_Pipe LSHIFT(Key_Backslash)
-#define Key_LSquareBracket (Key){ KEY_FLAGS, HID_KEYBOARD_LEFT_BRACKET_AND_LEFT_CURLY_BRACE }
-#define Key_RSquareBracket (Key){ KEY_FLAGS, HID_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_CURLY_BRACE }
+#define Key_LSquareBracket (Key) { HID_KEYBOARD_LEFT_BRACKET_AND_LEFT_CURLY_BRACE,  KEY_FLAGS }
+#define Key_RSquareBracket (Key) { HID_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_CURLY_BRACE,  KEY_FLAGS }
 #define Key_LCurlyBracket LSHIFT(Key_LSquareBracket)
 #define Key_RCurlyBracket LSHIFT(Key_RSquareBracket)
-#define Key_Semicolon (Key){ KEY_FLAGS, HID_KEYBOARD_SEMICOLON_AND_COLON }
-#define Key_Quote (Key){ KEY_FLAGS, HID_KEYBOARD_QUOTE_AND_DOUBLEQUOTE }
-#define Key_Comma (Key){ KEY_FLAGS, HID_KEYBOARD_COMMA_AND_LESS_THAN }
-#define Key_Period (Key){ KEY_FLAGS, HID_KEYBOARD_PERIOD_AND_GREATER_THAN }
-#define Key_Space (Key){ KEY_FLAGS, HID_KEYBOARD_SPACEBAR}
-#define Key_Slash (Key){ KEY_FLAGS, HID_KEYBOARD_SLASH_AND_QUESTION_MARK }
+#define Key_Semicolon (Key) { HID_KEYBOARD_SEMICOLON_AND_COLON,  KEY_FLAGS }
+#define Key_Quote (Key) { HID_KEYBOARD_QUOTE_AND_DOUBLEQUOTE,  KEY_FLAGS }
+#define Key_Comma (Key) { HID_KEYBOARD_COMMA_AND_LESS_THAN,  KEY_FLAGS }
+#define Key_Period (Key) { HID_KEYBOARD_PERIOD_AND_GREATER_THAN,  KEY_FLAGS }
+#define Key_Space (Key) { HID_KEYBOARD_SPACEBAR,  KEY_FLAGS }
+#define Key_Slash (Key) { HID_KEYBOARD_SLASH_AND_QUESTION_MARK,  KEY_FLAGS }
 
 #define Key_LEFT_PAREN LSHIFT(Key_9)
 #define Key_RIGHT_PAREN LSHIFT(Key_0)
 
 
-#define Key_KeypadClear (Key){ KEY_FLAGS, HID_KEYPAD_CLEAR }
-#define Key_KeypadSlash (Key){ KEY_FLAGS, HID_KEYPAD_DIVIDE }
-#define Key_KeypadMultiply (Key){ KEY_FLAGS, HID_KEYPAD_MULTIPLY }
-#define Key_KeypadMinus (Key){ KEY_FLAGS, HID_KEYPAD_SUBTRACT }
-#define Key_KeypadPlus (Key){ KEY_FLAGS, HID_KEYPAD_ADD }
-#define Key_Enter (Key){ KEY_FLAGS, HID_KEYBOARD_ENTER }
-#define Key_Keypad1 (Key){ KEY_FLAGS, HID_KEYPAD_1_AND_END }
-#define Key_Keypad2 (Key){ KEY_FLAGS, HID_KEYPAD_2_AND_DOWN_ARROW}
-#define Key_Keypad3 (Key){ KEY_FLAGS, HID_KEYPAD_3_AND_PAGE_DOWN}
-#define Key_Keypad4 (Key){ KEY_FLAGS, HID_KEYPAD_4_AND_LEFT_ARROW }
-#define Key_Keypad5 (Key){ KEY_FLAGS, HID_KEYPAD_5 }
-#define Key_Keypad6 (Key){ KEY_FLAGS, HID_KEYPAD_6_AND_RIGHT_ARROW }
-#define Key_Keypad7 (Key){ KEY_FLAGS, HID_KEYPAD_7_AND_HOME }
-#define Key_Keypad8 (Key){ KEY_FLAGS, HID_KEYPAD_8_AND_UP_ARROW }
-#define Key_Keypad9 (Key){ KEY_FLAGS, HID_KEYPAD_9_AND_PAGE_UP }
-#define Key_Keypad0 (Key){ KEY_FLAGS, HID_KEYPAD_0_AND_INSERT }
-#define Key_KeypadDot (Key){ KEY_FLAGS, HID_KEYPAD_PERIOD_AND_DELETE }
-#define Key_PcApplciation (Key){ KEY_FLAGS, HID_KEYBOARD_APPLICATION }
-#define Key_Help (Key){ KEY_FLAGS, HID_KEYBOARD_HELP }
+#define Key_KeypadClear (Key) { HID_KEYPAD_CLEAR,  KEY_FLAGS }
+#define Key_KeypadSlash (Key) { HID_KEYPAD_DIVIDE,  KEY_FLAGS }
+#define Key_KeypadMultiply (Key) { HID_KEYPAD_MULTIPLY,  KEY_FLAGS }
+#define Key_KeypadMinus (Key) { HID_KEYPAD_SUBTRACT,  KEY_FLAGS }
+#define Key_KeypadPlus (Key) { HID_KEYPAD_ADD,  KEY_FLAGS }
+#define Key_Enter (Key) { HID_KEYBOARD_ENTER,  KEY_FLAGS }
+#define Key_Keypad1 (Key) { HID_KEYPAD_1_AND_END,  KEY_FLAGS }
+#define Key_Keypad2 (Key) { HID_KEYPAD_2_AND_DOWN_ARROW,  KEY_FLAGS }
+#define Key_Keypad3 (Key) { HID_KEYPAD_3_AND_PAGE_DOWN,  KEY_FLAGS }
+#define Key_Keypad4 (Key) { HID_KEYPAD_4_AND_LEFT_ARROW,  KEY_FLAGS }
+#define Key_Keypad5 (Key) { HID_KEYPAD_5,  KEY_FLAGS }
+#define Key_Keypad6 (Key) { HID_KEYPAD_6_AND_RIGHT_ARROW,  KEY_FLAGS }
+#define Key_Keypad7 (Key) { HID_KEYPAD_7_AND_HOME,  KEY_FLAGS }
+#define Key_Keypad8 (Key) { HID_KEYPAD_8_AND_UP_ARROW,  KEY_FLAGS }
+#define Key_Keypad9 (Key) { HID_KEYPAD_9_AND_PAGE_UP,  KEY_FLAGS }
+#define Key_Keypad0 (Key) { HID_KEYPAD_0_AND_INSERT,  KEY_FLAGS }
+#define Key_KeypadDot (Key) { HID_KEYPAD_PERIOD_AND_DELETE,  KEY_FLAGS }
+#define Key_PcApplciation (Key) { HID_KEYBOARD_APPLICATION,  KEY_FLAGS }
+#define Key_Help (Key) { HID_KEYBOARD_HELP,  KEY_FLAGS }
 #define KEY_BACKLIGHT_DOWN 0xF1
 #define KEY_BACKLIGHT_UP 0xF2
-#define Key_BacklightDn (Key){ KEY_FLAGS, KEY_BACKLIGHT_DOWN }
-#define Key_BacklightUp (Key){ KEY_FLAGS, KEY_BACKLIGHT_UP }
+#define Key_BacklightDn (Key) { KEY_BACKLIGHT_DOWN,  KEY_FLAGS }
+#define Key_BacklightUp (Key) { KEY_BACKLIGHT_UP,  KEY_FLAGS }
 #define KEY_RIGHT_FN2 0xfe
-#define Key_RFN2 (Key){ KEY_FLAGS, KEY_RIGHT_FN2 }
+#define Key_RFN2 (Key) { KEY_RIGHT_FN2,  KEY_FLAGS }
 #define KEY_LEFT_FN2 0xff
-#define Key_LFN2 (Key){ KEY_FLAGS, KEY_LEFT_FN2 }
+#define Key_LFN2 (Key) { KEY_LEFT_FN2,  KEY_FLAGS }
 
-#define Key_Undo (Key){ KEY_FLAGS, HID_KEYBOARD_UNDO }
-#define Key_Cut (Key){ KEY_FLAGS, HID_KEYBOARD_CUT }
-#define Key_Copy (Key){ KEY_FLAGS, HID_KEYBOARD_COPY }
-#define Key_Paste (Key){ KEY_FLAGS, HID_KEYBOARD_PASTE }
+#define Key_Undo (Key) { HID_KEYBOARD_UNDO,  KEY_FLAGS }
+#define Key_Cut (Key) { HID_KEYBOARD_CUT,  KEY_FLAGS }
+#define Key_Copy (Key) { HID_KEYBOARD_COPY,  KEY_FLAGS }
+#define Key_Paste (Key) { HID_KEYBOARD_PASTE,  KEY_FLAGS }
 
 
-#define Key_Keymap0 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_0 }
-#define Key_Keymap1 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_1 }
-#define Key_Keymap2 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_2 }
-#define Key_Keymap3 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_3 }
-#define Key_Keymap4 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_4 }
-#define Key_Keymap5 (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP , KEYMAP_5 }
+#define Key_Keymap0 (Key) { KEYMAP_0,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
+#define Key_Keymap1 (Key) { KEYMAP_1,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
+#define Key_Keymap2 (Key) { KEYMAP_2,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
+#define Key_Keymap3 (Key) { KEYMAP_3,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
+#define Key_Keymap4 (Key) { KEYMAP_4,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
+#define Key_Keymap5 (Key) { KEYMAP_5,  KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP  }
 #define Key_Keymap0_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_0 + MOMENTARY_OFFSET}
 #define Key_Keymap1_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_1 + MOMENTARY_OFFSET}
 #define Key_Keymap2_Momentary (Key){ KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP, KEYMAP_2 + MOMENTARY_OFFSET }
@@ -270,4 +270,4 @@ typedef union Key_ {
 
 
 
-#define Key_LEDEffectNext (Key) { KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE, 0 }
+#define Key_LEDEffectNext (Key) { 0,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE }


### PR DESCRIPTION
With the swap, using `raw` becomes more straightforward, because the flags will occupy the higher bits, and the keyCode the lower ones. This makes range checks much more intuitive.

Will have to adjust the plugins accordingly, I'll do that if/when this is merged.