### PR TITLE
Turn the NumLock key into a macro

### DIFF
--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -7,12 +7,12 @@
 #include "Keyboardio-MouseKeys.h"
 #include "Keyboardio-Macros.h"
 #include "Keyboardio-LEDControl.h"
+#include "Keyboardio-Numlock.h"
 #include "KeyboardioFirmware.h"
 #include "generated/keymaps.h"
 
 #include "LED-Off.h"
 #include "Keyboardio-LEDEffect-SolidColor.h"
-#include "Keyboardio-LEDEffect-Numlock.h"
 #include "Keyboardio-LEDEffect-Breathe.h"
 #include "Keyboardio-LEDEffect-Chase.h"
 #include "Keyboardio-LEDEffect-Rainbow.h"

--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -33,9 +33,9 @@ static LEDSolidColor solidBlue (0, 30, 200);
 static LEDSolidColor solidIndigo (0, 0, 200);
 static LEDSolidColor solidViolet (100, 0, 120);
 
-const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState) {
-    if (macroIndex == 0 && key_toggled_on(keyState)) {
-        return NumLock.toggle (row, col, NUMPAD_KEYMAP);
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+    if (macroIndex == TOGGLENUMLOCK && key_toggled_on(keyState)) {
+        return NumLock.toggle (Macros.row, Macros.col, NUMPAD_KEYMAP);
     }
 
     if (macroIndex == 1 && key_toggled_on(keyState)) {

--- a/examples/KeyboardioFirmware/KeyboardioFirmware.ino
+++ b/examples/KeyboardioFirmware/KeyboardioFirmware.ino
@@ -33,9 +33,11 @@ static LEDSolidColor solidBlue (0, 30, 200);
 static LEDSolidColor solidIndigo (0, 0, 200);
 static LEDSolidColor solidViolet (100, 0, 120);
 
-static LEDNumlock numLockEffect (NUMPAD_KEYMAP);
+const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState) {
+    if (macroIndex == 0 && key_toggled_on(keyState)) {
+        return NumLock.toggle (row, col, NUMPAD_KEYMAP);
+    }
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
     if (macroIndex == 1 && key_toggled_on(keyState)) {
         Serial.print("Keyboard.IO keyboard driver v0.00");
         return MACRO(I(25),
@@ -53,7 +55,7 @@ void setup() {
 
     Keyboardio.use(&LEDControl, &LEDOff,
                    &solidRed, &solidOrange, &solidYellow, &solidGreen, &solidBlue, &solidIndigo, &solidViolet,
-                   &LEDBreatheEffect, &LEDRainbowEffect, &LEDChaseEffect, &numLockEffect,
+                   &LEDBreatheEffect, &LEDRainbowEffect, &LEDChaseEffect, &NumLock,
 
                    &Macros,
                    &MouseKeys,

--- a/examples/KeyboardioFirmware/generated/keymaps.h
+++ b/examples/KeyboardioFirmware/generated/keymaps.h
@@ -31,7 +31,7 @@
 	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
 	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
 },
-#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Keymap2},\
+#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, M(0)},\
 	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab, Key_Backspace, Key_Space, Key_Enter, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
 	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Esc, Key_LGUI, Key_RAlt, Key_skip, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
 	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_KeymapNext_Momentary, Key_LShift, Key_RShift, Key_KeymapNext_Momentary, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\

--- a/examples/KeyboardioFirmware/generated/keymaps.h
+++ b/examples/KeyboardioFirmware/generated/keymaps.h
@@ -31,7 +31,7 @@
 	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad1, Key_Keypad2, Key_Keypad3, Key_Equals, Key_Quote},\
 	{___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadSlash, Key_Enter},\
 },
-#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, M(0)},\
+#define KEYMAP_QWERTY { /* Generated keymap for QWERTY */ 	{Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext, Key_LCtrl, Key_RCtrl, Key_skip, Key_6, Key_7, Key_8, Key_9, Key_0, Key_ToggleNumlock},\
 	{Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab, Key_Backspace, Key_Space, Key_Enter, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_Equals},\
 	{Key_PageUp, Key_A, Key_S, Key_D, Key_F, Key_G, Key_Esc, Key_LGUI, Key_RAlt, Key_skip, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote},\
 	{Key_PageDn, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_KeymapNext_Momentary, Key_LShift, Key_RShift, Key_KeymapNext_Momentary, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_Minus},\

--- a/examples/KeyboardioFirmware/layouts/qwerty
+++ b/examples/KeyboardioFirmware/layouts/qwerty
@@ -1,5 +1,5 @@
 #NAME: QWERTY
-LEDEffectNext	1 2 3 4 5  LEDEffectNext        LCtrl  RCtrl 	  skip                  6 7 8 9 0 M(0)
+LEDEffectNext	1 2 3 4 5  LEDEffectNext        LCtrl  RCtrl 	  skip                  6 7 8 9 0 ToggleNumlock
 `               Q W E R T  Tab                  Backspace Space   Enter  Y U I O P =
 PageUp 	        A S D F G  Esc                  LGUI    RAlt	  skip                H J K L ; '
 PageDn 	        Z X C V B  KeymapNext_Momentary LShift  RShift 	  KeymapNext_Momentary  N M , . / -

--- a/examples/KeyboardioFirmware/layouts/qwerty
+++ b/examples/KeyboardioFirmware/layouts/qwerty
@@ -1,5 +1,5 @@
 #NAME: QWERTY
-LEDEffectNext	1 2 3 4 5  LEDEffectNext        LCtrl  RCtrl 	  skip                  6 7 8 9 0 Keymap2
+LEDEffectNext	1 2 3 4 5  LEDEffectNext        LCtrl  RCtrl 	  skip                  6 7 8 9 0 M(0)
 `               Q W E R T  Tab                  Backspace Space   Enter  Y U I O P =
 PageUp 	        A S D F G  Esc                  LGUI    RAlt	  skip                H J K L ; '
 PageDn 	        Z X C V B  KeymapNext_Momentary LShift  RShift 	  KeymapNext_Momentary  N M , . / -


### PR DESCRIPTION
Instead of just switching to a layer, make it a macro. The macro will toggle the layer and the LED effect.

Depends on keyboardio/Keyboardio-Macros#1 and keyboardio/Keyboardio-LEDEffect-Numlock#2.

Appears to work fine after a quick test.