### PR TITLE
keyboardio-builder: Drop submodule_update

### DIFF
--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -16,23 +16,6 @@ firmware_size () {
 	echo "${output}" | sed -e "s,\(Program:.*\)(\([0-9\.]*%\) Full),\1(${PERCENT}% Full),"
 }
 
-submodule_update () {
-    cd $(dirname $0)/..
-
-    echo Syncing submodules...
-    git submodule --quiet sync --recursive
-
-    echo Updating submodules...
-    git submodule --quiet update --init --recursive
-
-    echo
-
-    for lib in hardware/keyboardio/avr/libraries/* lib/*; do
-        echo Updating $(basename ${lib})...
-        (cd $lib; git checkout -q master; git pull -q --ff)
-    done
-}
-
 find_sketch () {
     if [ -e "${SOURCEDIR}/.keyboardio-builder.conf" ]; then
         . "${SOURCEDIR}/.keyboardio-builder.conf"


### PR DESCRIPTION
The function is broken, and does not belong here in the first place. It was a remnant of how Akela was set up, but makes no sense in general.
