### PR TITLE
tools/keyboardio-builder: Fix the build-all command

### DIFF
--- a/tools/keyboardio-builder
+++ b/tools/keyboardio-builder
@@ -169,7 +169,7 @@ build_all () {
     for plugin in ${plugins}; do
         export SKETCH="${plugin}"
         export LIBRARY="${plugin}"
-        (build ${plugin})
+        $0 ${plugin} build
     done
 }
 


### PR DESCRIPTION
The build-all command needs a clean(-ish) slate, and must re-set the build-dir, otherwise a successful build of a previous plugin will remove it. As a workaround, re-launch the builder in this case.
